### PR TITLE
fix: update middleware to use BurgerNext type for next function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
- 
 <p align="center">
   <img src="https://github.com/user-attachments/assets/0d9b376e-1d89-479a-aa7f-e7ee3c6b2342" alt="BurgerAPI logo"/>
 </p>
-
 
 [![Under Development](https://img.shields.io/badge/under%20development-red.svg)](https://github.com/isfhan/burger-api) [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Bun](https://img.shields.io/badge/Bun-1.2.4-black?logo=bun)](https://bun.sh)
 
@@ -215,12 +213,12 @@ Here's how to implement this structure:
 1. **Global Middleware** (`src/middleware/global/logger.ts`):
 
 ```ts
-import type { BurgerRequest, BurgerResponse } from "burger-api";
+import type { BurgerRequest, BurgerResponse, BurgerNext } from "burger-api";
 
 export const logger = async (
   req: BurgerRequest,
   res: BurgerResponse,
-  next: () => Promise<Response>
+  next: BurgerNext
 ) => {
   console.log(`[${new Date().toISOString()}] ${req.method} ${req.url}`);
   return next();
@@ -230,12 +228,12 @@ export const logger = async (
 2. **Route-Specific Middleware** (`src/middleware/routes/products.ts`):
 
 ```ts
-import type { BurgerRequest, BurgerResponse } from "burger-api";
+import type { BurgerRequest, BurgerResponse, BurgerNext } from "burger-api";
 
 export const validateProductAccess = async (
   req: BurgerRequest,
   res: BurgerResponse,
-  next: () => Promise<Response>
+  next: BurgerNext
 ) => {
   // Your middleware logic here
   return next();
@@ -394,7 +392,7 @@ Below is an example route file demonstrating schema validation, route-specific m
 // examples/demo/api/product/[id]/route.ts
 
 import { z } from "zod";
-import type { BurgerRequest, BurgerResponse } from "burger-api";
+import type { BurgerRequest, BurgerResponse, BurgerNext } from "burger-api";
 
 // OpenAPI metadata for this route
 export const openapi = {
@@ -429,11 +427,7 @@ export const schema = {
 
 // Route-specific middleware
 export const middleware = [
-  async (
-    req: BurgerRequest,
-    res: BurgerResponse,
-    next: () => Promise<Response>
-  ) => {
+  async (req: BurgerRequest, res: BurgerResponse, next: BurgerNext) => {
     console.log("[Product Middleware] Executing product route middleware");
     return next();
   },

--- a/examples/error-handling/api/products/[id]/route.ts
+++ b/examples/error-handling/api/products/[id]/route.ts
@@ -2,7 +2,11 @@
 import { z } from "zod";
 
 // Import types
-import type { BurgerRequest, BurgerResponse } from "../../../../../src/types";
+import type {
+  BurgerRequest,
+  BurgerResponse,
+  BurgerNext,
+} from "../../../../../src/types";
 
 // OpenAPI Metadata
 // Developers can provide custom metadata to enrich the docs.
@@ -38,20 +42,13 @@ export const schema = {
 
 // Route-Specific Middleware
 export const middleware = [
-  async (
-    req: BurgerRequest,
-    res: BurgerResponse,
-    next: () => Promise<Response>
-  ) => {
+  async (req: BurgerRequest, res: BurgerResponse, next: BurgerNext) => {
     console.log("Product Detail Middleware");
     return next();
   },
 ];
 
-export async function GET(
-  req: BurgerRequest,
-  res: BurgerResponse,
-) {
+export async function GET(req: BurgerRequest, res: BurgerResponse) {
   console.log("[GET] Dynamic Product route invoked");
 
   // Use validated parameters if available; otherwise, fallback to resolved params.

--- a/examples/error-handling/api/products/route.ts
+++ b/examples/error-handling/api/products/route.ts
@@ -2,7 +2,11 @@
 import { z } from "zod";
 
 // Import types
-import type { BurgerRequest, BurgerResponse } from "../../../../src/types";
+import type {
+  BurgerRequest,
+  BurgerResponse,
+  BurgerNext,
+} from "../../../../src/types";
 
 // OpenAPI Metadata
 // Developers can provide custom metadata to enrich the docs.
@@ -29,11 +33,7 @@ export const schema = {
 
 // Route-Specific Middleware
 export const middleware = [
-  async (
-    req: BurgerRequest,
-    res: BurgerResponse,
-    next: () => Promise<Response>
-  ) => {
+  async (req: BurgerRequest, res: BurgerResponse, next: BurgerNext) => {
     console.log("Products Middleware");
     return next();
   },

--- a/examples/error-handling/middleware/logger.ts
+++ b/examples/error-handling/middleware/logger.ts
@@ -1,10 +1,15 @@
-import type { BurgerRequest, BurgerResponse, Middleware } from "../../../src";
+import type {
+  Middleware,
+  BurgerRequest,
+  BurgerResponse,
+  BurgerNext,
+} from "../../../src";
 
 // Global middleware example: a simple logger.
 export const globalLogger: Middleware = async (
   req: BurgerRequest,
   res: BurgerResponse,
-  next: () => Promise<Response>
+  next: BurgerNext
 ) => {
   console.log(`[Global Logger] ${req.method} ${req.url}`);
   return next();

--- a/examples/file-base-api-routing/middleware/index.ts
+++ b/examples/file-base-api-routing/middleware/index.ts
@@ -1,4 +1,9 @@
-import type { BurgerRequest, BurgerResponse, Middleware } from "../../../src/types/";
+import type {
+  Middleware,
+  BurgerRequest,
+  BurgerResponse,
+  BurgerNext,
+} from "../../../src/types/index.js";
 
 /**
  * Example of a global middleware function. This middleware logs a message to
@@ -11,7 +16,7 @@ import type { BurgerRequest, BurgerResponse, Middleware } from "../../../src/typ
 export const globalMiddleware1: Middleware = async (
   req: BurgerRequest,
   res: BurgerResponse,
-  next: () => Promise<Response>
+  next: BurgerNext
 ) => {
   console.log("Global middleware executed.");
 

--- a/examples/file-base-static-page-routing-app/api/products/[id]/route.ts
+++ b/examples/file-base-static-page-routing-app/api/products/[id]/route.ts
@@ -2,7 +2,11 @@
 import { z } from "zod";
 
 // Import types
-import type { BurgerRequest, BurgerResponse } from "../../../../../src/types";
+import type {
+  BurgerRequest,
+  BurgerResponse,
+  BurgerNext,
+} from "../../../../../src/types";
 
 // OpenAPI Metadata
 // Developers can provide custom metadata to enrich the docs.
@@ -38,20 +42,13 @@ export const schema = {
 
 // Route-Specific Middleware
 export const middleware = [
-  async (
-    req: BurgerRequest,
-    res: BurgerResponse,
-    next: () => Promise<Response>
-  ) => {
+  async (req: BurgerRequest, res: BurgerResponse, next: BurgerNext) => {
     console.log("Product Detail Middleware");
     return next();
   },
 ];
 
-export async function GET(
-  req: BurgerRequest,
-  res: BurgerResponse,
-) {
+export async function GET(req: BurgerRequest, res: BurgerResponse) {
   console.log("[GET] Dynamic Product route invoked");
 
   // Use validated parameters if available; otherwise, fallback to resolved params.

--- a/examples/file-base-static-page-routing-app/api/products/route.ts
+++ b/examples/file-base-static-page-routing-app/api/products/route.ts
@@ -2,7 +2,11 @@
 import { z } from "zod";
 
 // Import types
-import type { BurgerRequest, BurgerResponse } from "../../../../src/types";
+import type {
+  BurgerRequest,
+  BurgerResponse,
+  BurgerNext,
+} from "../../../../src/types";
 
 // OpenAPI Metadata
 // Developers can provide custom metadata to enrich the docs.
@@ -29,11 +33,7 @@ export const schema = {
 
 // Route-Specific Middleware
 export const middleware = [
-  async (
-    req: BurgerRequest,
-    res: BurgerResponse,
-    next: () => Promise<Response>
-  ) => {
+  async (req: BurgerRequest, res: BurgerResponse, next: BurgerNext) => {
     console.log("Products Middleware");
     return next();
   },

--- a/examples/file-base-static-page-routing-app/middleware/logger.ts
+++ b/examples/file-base-static-page-routing-app/middleware/logger.ts
@@ -1,10 +1,15 @@
-import type { BurgerRequest, BurgerResponse, Middleware } from "../../../src";
+import type {
+  BurgerRequest,
+  BurgerResponse,
+  Middleware,
+  BurgerNext,
+} from "../../../src";
 
 // Global middleware example: a simple logger.
 export const globalLogger: Middleware = async (
   req: BurgerRequest,
   res: BurgerResponse,
-  next: () => Promise<Response>
+  next: BurgerNext
 ) => {
   console.log(`[Global Logger] ${req.method} ${req.url}`);
   return next();

--- a/examples/openapi-and-swagger-ui/api/products/[id]/route.ts
+++ b/examples/openapi-and-swagger-ui/api/products/[id]/route.ts
@@ -2,7 +2,11 @@
 import { z } from "zod";
 
 // Import types
-import type { BurgerRequest, BurgerResponse } from "../../../../../src/types";
+import type {
+  BurgerRequest,
+  BurgerResponse,
+  BurgerNext,
+} from "../../../../../src/types";
 
 // OpenAPI Metadata
 // Developers can provide custom metadata to enrich the docs.
@@ -38,20 +42,13 @@ export const schema = {
 
 // Route-Specific Middleware
 export const middleware = [
-  async (
-    req: BurgerRequest,
-    res: BurgerResponse,
-    next: () => Promise<Response>
-  ) => {
+  async (req: BurgerRequest, res: BurgerResponse, next: BurgerNext) => {
     console.log("Product Detail Middleware");
     return next();
   },
 ];
 
-export async function GET(
-  req: BurgerRequest,
-  res: BurgerResponse,
-) {
+export async function GET(req: BurgerRequest, res: BurgerResponse) {
   console.log("[GET] Product Detail route invoked");
 
   // Use validated parameters if available; otherwise, fallback to resolved params.

--- a/examples/openapi-and-swagger-ui/api/products/route.ts
+++ b/examples/openapi-and-swagger-ui/api/products/route.ts
@@ -2,7 +2,11 @@
 import { z } from "zod";
 
 // Import types
-import type { BurgerRequest, BurgerResponse } from "../../../../src/types";
+import type {
+  BurgerRequest,
+  BurgerResponse,
+  BurgerNext,
+} from "../../../../src/types";
 
 // OpenAPI Metadata
 // Developers can provide custom metadata to enrich the docs.
@@ -29,11 +33,7 @@ export const schema = {
 
 // Route-Specific Middleware
 export const middleware = [
-  async (
-    req: BurgerRequest,
-    res: BurgerResponse,
-    next: () => Promise<Response>
-  ) => {
+  async (req: BurgerRequest, res: BurgerResponse, next: BurgerNext) => {
     console.log("Products Middleware");
     return next();
   },

--- a/examples/openapi-and-swagger-ui/middleware/logger.ts
+++ b/examples/openapi-and-swagger-ui/middleware/logger.ts
@@ -1,10 +1,15 @@
-import type { BurgerRequest, BurgerResponse, Middleware } from "../../../src";
+import type {
+  Middleware,
+  BurgerRequest,
+  BurgerResponse,
+  BurgerNext,
+} from "../../../src";
 
 // Global middleware example: a simple logger.
 export const globalLogger: Middleware = async (
   req: BurgerRequest,
   res: BurgerResponse,
-  next: () => Promise<Response>
+  next: BurgerNext
 ) => {
   console.log(`[Global Logger] ${req.method} ${req.url}`);
   return next();

--- a/examples/route-specific-middleware/api/(group)/products/detail/route.ts
+++ b/examples/route-specific-middleware/api/(group)/products/detail/route.ts
@@ -1,12 +1,12 @@
-import { BurgerRequest, BurgerResponse } from "../../../../../../src";
+import type {
+  BurgerRequest,
+  BurgerResponse,
+  BurgerNext,
+} from "../../../../../../src";
 
 // Route-specific middleware
 export const middleware = [
-  async (
-    req: BurgerRequest,
-    res: BurgerResponse,
-    next: () => Promise<Response>
-  ) => {
+  async (req: BurgerRequest, res: BurgerResponse, next: BurgerNext) => {
     console.log("Product Detail Route-specific middleware executed");
     return await next();
   },

--- a/examples/route-specific-middleware/api/(group)/products/route.ts
+++ b/examples/route-specific-middleware/api/(group)/products/route.ts
@@ -1,12 +1,12 @@
-import { BurgerRequest, BurgerResponse } from "../../../../../src";
+import type {
+  BurgerRequest,
+  BurgerResponse,
+  BurgerNext,
+} from "../../../../../src";
 
 // Route-specific middleware
 export const middleware = [
-  async (
-    req: BurgerRequest,
-    res: BurgerResponse,
-    next: () => Promise<Response>
-  ) => {
+  async (req: BurgerRequest, res: BurgerResponse, next: BurgerNext) => {
     console.log("Product Route-specific middleware executed");
     return await next();
   },

--- a/examples/route-specific-middleware/api/(group)/profile/[id]/route.ts
+++ b/examples/route-specific-middleware/api/(group)/profile/[id]/route.ts
@@ -1,12 +1,12 @@
-import type { BurgerRequest, BurgerResponse } from "../../../../../../src";
+import type {
+  BurgerRequest,
+  BurgerResponse,
+  BurgerNext,
+} from "../../../../../../src";
 
 // Route-specific middleware
 export const middleware = [
-  async (
-    req: BurgerRequest,
-    res: BurgerResponse,
-    next: () => Promise<Response>
-  ) => {
+  async (req: BurgerRequest, res: BurgerResponse, next: BurgerNext) => {
     console.log("Profile Route-specific middleware executed");
     return await next();
   },

--- a/examples/route-specific-middleware/middleware/index.ts
+++ b/examples/route-specific-middleware/middleware/index.ts
@@ -1,7 +1,8 @@
 import type {
+  Middleware,
   BurgerRequest,
   BurgerResponse,
-  Middleware,
+  BurgerNext,
 } from "../../../src/types";
 
 /**
@@ -15,7 +16,7 @@ import type {
 export const globalMiddleware1: Middleware = async (
   req: BurgerRequest,
   res: BurgerResponse,
-  next: () => Promise<Response>
+  next: BurgerNext
 ) => {
   console.log("Global middleware executed.");
 

--- a/examples/zod-based-schema-validation/api/products/[id]/route.ts
+++ b/examples/zod-based-schema-validation/api/products/[id]/route.ts
@@ -2,7 +2,11 @@
 import { z } from "zod";
 
 // Import types
-import type { BurgerRequest, BurgerResponse } from "../../../../../src";
+import type {
+  BurgerRequest,
+  BurgerResponse,
+  BurgerNext,
+} from "../../../../../src";
 
 // Export a schema for GET requests.
 export const schema = {
@@ -15,11 +19,7 @@ export const schema = {
 
 // Route-specific middleware
 export const middleware = [
-  async (
-    req: BurgerRequest,
-    res: BurgerResponse,
-    next: () => Promise<Response>
-  ) => {
+  async (req: BurgerRequest, res: BurgerResponse, next: BurgerNext) => {
     console.log("Product Detail Route-specific middleware executed");
     return await next();
   },

--- a/examples/zod-based-schema-validation/api/products/route.ts
+++ b/examples/zod-based-schema-validation/api/products/route.ts
@@ -2,7 +2,11 @@
 import { z } from "zod";
 
 // Import types
-import type { BurgerRequest, BurgerResponse } from "../../../../src";
+import type {
+  BurgerRequest,
+  BurgerResponse,
+  BurgerNext,
+} from "../../../../src";
 
 // Export a schema for both GET and POST requests.
 // For GET, we validate the query parameters.
@@ -25,11 +29,7 @@ export const schema = {
 
 // Route-specific middleware
 export const middleware = [
-  async (
-    req: BurgerRequest,
-    res: BurgerResponse,
-    next: () => Promise<Response>
-  ) => {
+  async (req: BurgerRequest, res: BurgerResponse, next: BurgerNext) => {
     console.log("Product Route-specific middleware executed");
     return await next();
   },

--- a/examples/zod-based-schema-validation/middleware/index.ts
+++ b/examples/zod-based-schema-validation/middleware/index.ts
@@ -1,7 +1,8 @@
 import type {
+  Middleware,
   BurgerRequest,
   BurgerResponse,
-  Middleware,
+  BurgerNext,
 } from "../../../src/types";
 
 /**
@@ -15,7 +16,7 @@ import type {
 export const globalMiddleware1: Middleware = async (
   req: BurgerRequest,
   res: BurgerResponse,
-  next: () => Promise<Response>
+  next: BurgerNext
 ) => {
   console.log("Global middleware executed.");
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burger-api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Isfhan Ahmed",
   "type": "module",
   "module": "dist/src/index.js",

--- a/src/core/api-router.ts
+++ b/src/core/api-router.ts
@@ -12,7 +12,11 @@ import {
 } from "../utils/index.js";
 
 // Import types
-import type { RequestHandler, RouteDefinition } from "../types/index.js";
+import type {
+  Middleware,
+  RequestHandler,
+  RouteDefinition,
+} from "../types/index.js";
 
 /**
  * ApiRouter class for handling file-based routing.
@@ -127,10 +131,11 @@ export class ApiRouter {
       const routeDef: RouteDefinition = {
         path: routePath,
         handlers,
-        middleware: routeModule.middleware,
+        middleware: routeModule.middleware as Middleware[],
         schema: routeModule.schema,
         openapi: routeModule.openapi,
       };
+
       this.routes.push(routeDef);
     } catch (error) {
       throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,6 +198,7 @@ export type {
   RequestHandler,
   BurgerRequest,
   BurgerResponse,
+  BurgerNext,
   Middleware,
   openapi,
 } from "./types/index.js";

--- a/src/middleware/validator.ts
+++ b/src/middleware/validator.ts
@@ -1,9 +1,10 @@
 // Import types
 import type {
+  RouteSchema,
+  Middleware,
   BurgerRequest,
   BurgerResponse,
-  Middleware,
-  RouteSchema,
+  BurgerNext,
 } from "../types/index.js";
 
 /**
@@ -16,11 +17,7 @@ import type {
  * error details if validation fails.
  */
 export function createValidationMiddleware(schema: RouteSchema): Middleware {
-  return async (
-    req: BurgerRequest,
-    res: BurgerResponse,
-    next: () => Promise<Response>
-  ) => {
+  return async (req: BurgerRequest, res: BurgerResponse, next: BurgerNext) => {
     // If the request has been validated, continue.
     if (req.validated) {
       return await next();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -83,6 +83,8 @@ export interface BurgerRequest extends Request {
   };
 }
 
+
+
 export interface BurgerResponse {
   /**
    * Sets a header value.
@@ -171,6 +173,13 @@ export interface BurgerResponse {
 }
 
 /**
+ * Represents a next function in the request handling pipeline.
+ * This function is used to call the next middleware in the chain.
+ * It returns a Promise that resolves with a Response object.
+ */
+export type BurgerNext = () => Promise<Response>;
+
+/**
  * Represents a request handler function.
  * Request handler functions receive a BurgerRequest and BurgerResponse as
  * arguments. They must return a Response object, which can be either a Promise
@@ -199,7 +208,7 @@ export type RequestHandler = (
 export type Middleware = (
   request: BurgerRequest,
   response: BurgerResponse,
-  next: () => Promise<Response>
+  next: BurgerNext
 ) => Promise<Response>;
 
 export interface RouteDefinition {


### PR DESCRIPTION
- Replace all instances of next function type from `() => Promise<Response>` to `BurgerNext` across middleware implementations.
- Update README to reflect changes in middleware function signatures.
- Ensure consistency in type imports across examples and core files.