### PR TITLE
feat: add wildcard route support with [...] syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## 📣 Release Notes
 
+### Version 0.4.0 (October 21, 2025)
+
+-   🎯 **Wildcard Routes:**
+    -   Added wildcard routes using `[...]` folder name - matches any path after it
+    -   Create routes that handle multiple path segments automatically
+    -   Access all matched path parts through `wildcardParams` in your request
+    -   Routes are matched in order: exact paths first, then dynamic routes (like `[id]`), then wildcards last
+    -   Works inside dynamic routes too (example: `/api/users/[userId]/[...]`)
+    -   View wildcard routes in OpenAPI docs and Swagger UI
+    -   Added easy-to-follow examples showing different ways to use wildcard routes
+
 ### Version 0.3.0 (August 15, 2025)
 
 -   🔧 **Updated Zod to version 4:**

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Under Development](https://img.shields.io/badge/under%20development-red.svg)](https://github.com/isfhan/burger-api)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Bun](https://img.shields.io/badge/Bun-1.2.20-black?logo=bun)](https://bun.sh)
-[![Version](https://img.shields.io/badge/version-0.3.0-green.svg)](https://github.com/isfhan/burger-api/releases)
+[![Version](https://img.shields.io/badge/version-0.4.0-green.svg)](https://github.com/isfhan/burger-api/releases)
 
 **burger-api** is a modern, open source API framework built on
 [Bun.js](https://bun.sh). It combines the simplicity of file-based routing with
@@ -59,7 +59,17 @@ burger-api is built to offer a robust developer experience through:
 
 ## 📣 Changelog
 
-### Latest Version: 0.3.0 (August 15, 2025)
+### Latest Version: 0.4.0 (October 21, 2025)
+
+-   🎯 **Wildcard Routes:**
+    -   Added wildcard routes using `[...]` folder name - matches any path after it
+    -   Create routes that handle multiple path segments automatically
+    -   Access all matched path parts through `wildcardParams` in your request
+    -   Routes are matched in order: exact paths first, then dynamic routes (like `[id]`), then wildcards last
+    -   Works inside dynamic routes too (example: `/api/users/[userId]/[...]`)
+    -   View wildcard routes in OpenAPI docs and Swagger UI
+
+### Version 0.3.0 (August 15, 2025)
 
 -   🔧 **Updated Zod to version 4:**
     -   Updated Zod version from 3.x to 4.x

--- a/examples/wildcard-routes/api/admin/[...]/route.ts
+++ b/examples/wildcard-routes/api/admin/[...]/route.ts
@@ -1,0 +1,19 @@
+import type { BurgerRequest } from '@src';
+
+/**
+ * Admin wildcard route example
+ * Route: /api/admin/[...]
+ *
+ * Note: This route will match any path that starts with /api/admin/
+ */
+
+export async function GET(req: BurgerRequest) {
+    const wildcardParams = req.wildcardParams || [];
+    return Response.json({
+        message: 'Admin wildcard route working',
+        wildcardParams: wildcardParams,
+        adminPath: wildcardParams.join('/'),
+        segments: wildcardParams.length,
+        note: 'This demonstrates admin path handling with wildcard routes',
+    });
+}

--- a/examples/wildcard-routes/api/admin/route.ts
+++ b/examples/wildcard-routes/api/admin/route.ts
@@ -1,0 +1,14 @@
+import type { BurgerRequest } from '@src';
+
+/**
+ * Static admin route example
+ * Route: /api/admin
+ *
+ * Note: This route will handle the base path (/api/admin) since a static route exists as a sibling
+ */
+export async function GET(req: BurgerRequest) {
+    return Response.json({
+        message: 'Static admin route working',
+        note: 'This route handles base path (/api/admin) since a static route exists as a sibling',
+    });
+}

--- a/examples/wildcard-routes/api/auth/[...]/route.ts
+++ b/examples/wildcard-routes/api/auth/[...]/route.ts
@@ -1,0 +1,27 @@
+import type { BurgerRequest } from '@src';
+
+/**
+ * Documentation wildcard route (no static sibling)
+ * Route: /api/auth/[...]
+ *
+ * This demonstrates wildcard handling base path when no static route exists.
+ * Unlike /api/admin which has a static sibling, this route handles both:
+ * - /api/auth (base path with empty params)
+ * - /api/auth/login (with segments)
+ * - /api/auth/logout (with segments)
+ * - /api/auth/register (with segments)
+ * - /api/auth/forgot-password (with segments)
+ * - /api/auth/reset-password (with segments)
+ * - /api/auth/verify-email (with segments)
+ */
+
+export async function GET(req: BurgerRequest) {
+    const wildcardParams = req.wildcardParams || [];
+    return Response.json({
+        message: 'Auth wildcard route',
+        wildcardParams: wildcardParams,
+        authPath: wildcardParams.join('/'),
+        segments: wildcardParams.length,
+        note: 'This route handles base path (/api/auth) with wildcard parameters if provided since no static route exists as a sibling',
+    });
+}

--- a/examples/wildcard-routes/api/users/[userId]/[...]/route.ts
+++ b/examples/wildcard-routes/api/users/[userId]/[...]/route.ts
@@ -1,0 +1,37 @@
+import type { BurgerRequest } from '@src';
+import { z } from 'zod';
+
+/**
+ * Zod schema for the wildcard route inside dynamic route folder
+ * Route: /api/users/[userId]/[...]
+ *
+ * Note: This schema will validate the request params
+ */
+export const schema = {
+    get: {
+        params: z.object({
+            userId: z.string().min(1, 'User ID is required'),
+        }),
+    },
+};
+
+/**
+ * Wildcard route inside dynamic route folder example
+ *
+ * Note: This route will handle the path (/api/users/[userId]/[...]) with the dynamic user id and the wildcard parameters
+ */
+export async function GET(
+    req: BurgerRequest<{ params: z.infer<typeof schema.get.params> }>
+) {
+    const { userId } = req.validated.params;
+    const wildcardParams = req.wildcardParams || [];
+    return Response.json({
+        message: 'Wildcard route example working',
+        level: 'wildcard route inside dynamic route folder example',
+        note: 'This route handles the path (/api/users/[userId]/[...]) with the dynamic user id and the wildcard parameters',
+        userId: userId,
+        wildcardParams: wildcardParams,
+        userPath: `${userId}/${wildcardParams.join('/')}`,
+        segments: wildcardParams.length,
+    });
+}

--- a/examples/wildcard-routes/api/users/[userId]/posts/[postId]/route.ts
+++ b/examples/wildcard-routes/api/users/[userId]/posts/[postId]/route.ts
@@ -1,0 +1,36 @@
+import type { BurgerRequest } from '@src';
+import { z } from 'zod';
+
+/**
+ * Zod schema for the nested dynamic route and wildcard route sibling example
+ * Route: /api/users/[userId]/posts/[postId]
+ *
+ * Note: This schema will validate the request params
+ */
+export const schema = {
+    get: {
+        params: z.object({
+            userId: z.string().min(1, 'User ID is required'),
+            postId: z.string().min(1, 'Post ID is required'),
+        }),
+    },
+};
+
+/**
+ * Nested dynamic route and wildcard route sibling example
+ * This route handles the path (/api/users/[userId]/posts/[postId]) with the dynamic user id and the dynamic post id
+ * Note: This route will return the post details for the given user id and post id
+ */
+export async function GET(
+    req: BurgerRequest<{ params: z.infer<typeof schema.get.params> }>
+) {
+    const { userId, postId } = req.validated.params;
+    return Response.json({
+        message:
+            'Nested dynamic route and wildcard route sibling example working',
+        note: 'This route handles the path (/api/users/[userId]/posts/[postId]) with the dynamic user id and the dynamic post id',
+        userId: userId,
+        postId: postId,
+        level: 'nested dynamic route and wildcard route sibling example',
+    });
+}

--- a/examples/wildcard-routes/api/users/[userId]/route.ts
+++ b/examples/wildcard-routes/api/users/[userId]/route.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+import type { BurgerRequest } from '@src';
+
+// Dummy users data
+const users = [
+    { id: 1, name: 'John Doe' },
+    { id: 2, name: 'Jane Doe' },
+    { id: 3, name: 'John Smith' },
+    { id: 4, name: 'Jane Smith' },
+];
+
+/**
+ * Zod schema for the dynamic route
+ * Route: /api/users/[userId]
+ *
+ * Note: This schema will validate the request params
+ */
+export const schema = {
+    get: {
+        params: z.object({
+            userId: z.string().min(1, 'User ID is required'),
+        }),
+    },
+};
+
+/**
+ * Dynamic user details route example
+ * Route: /api/users/[userId]
+ *
+ * Note: This route will handle the path (/api/users/[userId]) with the dynamic user id
+ */
+export async function GET(
+    req: BurgerRequest<{ params: z.infer<typeof schema.get.params> }>
+) {
+    const { userId } = req.validated.params;
+    const user = users.find((user) => user.id === parseInt(userId)) || null;
+    if (!user) {
+        return Response.json(
+            {
+                message: 'User not found',
+                user: null,
+                note: 'This route handles the path (/api/users/[userId]) with the dynamic user id',
+                level: 'dynamic route example',
+            },
+            { status: 404 }
+        );
+    }
+    return Response.json({
+        message: 'User found',
+        user: user,
+        note: 'This route handles the path (/api/users/[userId]) with the dynamic user id and returns the user details',
+        level: 'dynamic route example',
+    });
+}

--- a/examples/wildcard-routes/api/users/route.ts
+++ b/examples/wildcard-routes/api/users/route.ts
@@ -1,0 +1,21 @@
+import type { BurgerRequest } from '@src';
+
+/**
+ * Static route example
+ * Route: /api/users
+ *
+ * Note: This route will handle the base path (/api/users)
+ */
+export async function GET(req: BurgerRequest) {
+    return Response.json({
+        message: 'Users list route working',
+        note: 'This route handles the base path (/api/users)',
+        users: [
+            { id: 1, name: 'John Doe' },
+            { id: 2, name: 'Jane Doe' },
+            { id: 3, name: 'John Smith' },
+            { id: 4, name: 'Jane Smith' },
+        ],
+        level: 'static route example',
+    });
+}

--- a/examples/wildcard-routes/index.ts
+++ b/examples/wildcard-routes/index.ts
@@ -1,0 +1,13 @@
+// Wildcard Routes Example
+import { Burger, setDir } from '@src';
+
+// Create a new burger instance with wildcard routing
+const burger = new Burger({
+    title: 'BurgerAPI with Wildcard Routes',
+    description: 'Demonstrating wildcard routes using [...] syntax',
+    apiDir: setDir(__dirname, 'api'),
+    debug: true, // Enable debug for better error messages
+});
+
+// Start the server
+burger.serve(4000);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "burger-api",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": "Isfhan Ahmed",
   "type": "module",
   "module": "dist/src/index.js",

--- a/src/core/api-router.ts
+++ b/src/core/api-router.ts
@@ -21,8 +21,8 @@ import type {
 /**
  * ApiRouter class for handling file-based routing.
  * Loads routes from a directory structure and matches requests to the appropriate route handlers.
- * Supports dynamic segments (e.g., [id]) and HTTP method handlers.
- * Routes are sorted to prioritize static routes over dynamic ones to prevent overlapping route issues.
+ * Supports dynamic segments (e.g., [id] ,(group),[...]) and HTTP method handlers.
+ * Routes are sorted to prioritize static routes over dynamic and wildcard ones to prevent overlapping route issues.
  */
 export class ApiRouter {
     /** The root of the trie where all routes will begin*/
@@ -73,12 +73,21 @@ export class ApiRouter {
         const segments = routeDef.path.split('/').filter(Boolean);
         for (const segment of segments) {
             if (segment.startsWith(':')) {
+                // Handle dynamic segments (:param)
                 if (!node.paramChild) {
                     node.paramChild = { children: new Map() };
                 }
                 node = node.paramChild;
                 node.paramName = segment.slice(1);
+            } else if (segment.startsWith('*')) {
+                // Handle wildcard segments (*param)
+                if (!node.wildcardChild) {
+                    node.wildcardChild = { children: new Map() };
+                }
+                node = node.wildcardChild;
+                node.isWildcard = true; // Mark as wildcard route
             } else {
+                // Handle static segments
                 if (!node.children.has(segment)) {
                     node.children.set(segment, { children: new Map() });
                 }
@@ -99,8 +108,9 @@ export class ApiRouter {
         dir: string,
         basePath: string = ''
     ): Promise<void> {
-        // Track if a dynamic folder has been found at this directory level
+        // Track route types at this directory level to prevent conflicts
         let dynamicFolderFound = false;
+        let wildcardFolderFound = false;
 
         try {
             const entries = await readdir(dir, { withFileTypes: true });
@@ -109,20 +119,52 @@ export class ApiRouter {
                 const relativePath = path.join(basePath, entry.name);
 
                 if (entry.isDirectory()) {
-                    // Handle dynamic directories (e.g., [id])
-                    if (
+                    // Check if this is a dynamic or wildcard directory
+                    const isDynamic =
                         entry.name.startsWith(
                             ROUTE_CONSTANTS.DYNAMIC_FOLDER_START
                         ) &&
-                        entry.name.endsWith(ROUTE_CONSTANTS.DYNAMIC_FOLDER_END)
-                    ) {
-                        if (dynamicFolderFound) {
-                            throw new Error(
-                                `Multiple dynamic route folders found in the same directory: '${entry.name}' conflicts with another dynamic folder in '${dir}'.`
-                            );
-                        }
-                        dynamicFolderFound = true;
+                        entry.name.endsWith(
+                            ROUTE_CONSTANTS.DYNAMIC_FOLDER_END
+                        ) &&
+                        entry.name !== ROUTE_CONSTANTS.WILDCARD_SIMPLE;
+
+                    const isWildcard =
+                        entry.name === ROUTE_CONSTANTS.WILDCARD_SIMPLE;
+
+                    // Prevent conflicts between dynamic and wildcard routes
+                    if (isDynamic && wildcardFolderFound) {
+                        throw new Error(
+                            `Cannot mix dynamic and wildcard route folders in the same directory. ` +
+                                `Found dynamic folder '${entry.name}' but wildcard folder already exists in '${dir}'.`
+                        );
                     }
+
+                    if (isWildcard && dynamicFolderFound) {
+                        throw new Error(
+                            `Cannot mix wildcard and dynamic route folders in the same directory. ` +
+                                `Found wildcard folder '${entry.name}' but dynamic folder already exists in '${dir}'.`
+                        );
+                    }
+
+                    if (isDynamic && dynamicFolderFound) {
+                        throw new Error(
+                            `Multiple dynamic route folders found in the same directory: ` +
+                                `'${entry.name}' conflicts with another dynamic folder in '${dir}'.`
+                        );
+                    }
+
+                    if (isWildcard && wildcardFolderFound) {
+                        throw new Error(
+                            `Multiple wildcard route folders found in the same directory: ` +
+                                `'${entry.name}' conflicts with another wildcard folder in '${dir}'.`
+                        );
+                    }
+
+                    // Update flags
+                    if (isDynamic) dynamicFolderFound = true;
+                    if (isWildcard) wildcardFolderFound = true;
+
                     await this.scanDirectory(entryPath, relativePath);
                 } else if (entry.isFile() && entry.name === 'route.ts') {
                     await this.loadRouteModule(entryPath, relativePath);
@@ -176,6 +218,9 @@ export class ApiRouter {
                 middleware: routeModule.middleware as Middleware[],
                 schema: routeModule.schema,
                 openapi: routeModule.openapi,
+                isWildcard: routePath.includes(
+                    ROUTE_CONSTANTS.WILDCARD_SEGMENT_PREFIX
+                ),
             };
 
             this.insertRoute(routeDef);
@@ -187,9 +232,9 @@ export class ApiRouter {
     }
 
     /**
-     * Converts a file path to a route path by processing dynamic segments and applying the prefix.
-     * @param filePath The file path to convert (e.g., "users/[id]/route.ts").
-     * @returns {string} The converted route path (e.g., "/users/:id").
+     * Converts a file path to a route path by processing dynamic segments and wildcard segments applying the prefix.
+     * @param filePath The file path to convert (e.g., "users/[id]/route.ts" , "users/[...slug]/route.ts").
+     * @returns {string} The converted route path (e.g., "/users/:id" , "/users/*slug").
      */
     private convertFilePathToRoute(filePath: string): string {
         // Remove the "route.ts" suffix
@@ -208,18 +253,25 @@ export class ApiRouter {
             if (
                 segment.startsWith(ROUTE_CONSTANTS.GROUPING_FOLDER_START) &&
                 segment.endsWith(ROUTE_CONSTANTS.GROUPING_FOLDER_END)
-            )
+            ) {
                 continue;
+            }
 
             // Convert dynamic segments from [param] to :param
             if (
                 segment.startsWith(ROUTE_CONSTANTS.DYNAMIC_FOLDER_START) &&
-                segment.endsWith(ROUTE_CONSTANTS.DYNAMIC_FOLDER_END)
+                segment.endsWith(ROUTE_CONSTANTS.DYNAMIC_FOLDER_END) &&
+                !segment.startsWith(ROUTE_CONSTANTS.WILDCARD_START)
             ) {
                 const param = segment.slice(1, -1);
+
                 resultSegments.push(
                     ROUTE_CONSTANTS.DYNAMIC_SEGMENT_PREFIX + param
                 );
+            }
+            // Convert wildcard segments from [...] to *
+            else if (segment === ROUTE_CONSTANTS.WILDCARD_SIMPLE) {
+                resultSegments.push(ROUTE_CONSTANTS.WILDCARD_SEGMENT_PREFIX);
             } else {
                 resultSegments.push(segment);
             }
@@ -246,7 +298,7 @@ export class ApiRouter {
      * Resolves a request to a route definition and its parameters.
      * @param pathname  The normalized request pathname.
      * @param method The uppercase HTTP method.
-     * @returns {{ route?: RouteDefinition; params: Record<string, string> }} An object containing the matched route (if any) and extracted parameters.
+     * @returns {{ route?: RouteDefinition; params: Record<string, string>; wildcardParams?: string[] }} An object containing the matched route (if any), extracted parameters, and wildcard segments (if applicable).
      * @throws {Error} If the request URL is malformed.
      */
     public resolve(
@@ -255,27 +307,52 @@ export class ApiRouter {
     ): {
         route?: RouteDefinition;
         params: Record<string, string>;
+        wildcardParams?: string[];
     } {
         try {
             const segments = pathname.split('/').filter(Boolean);
-
             let node = this.root;
             const params: Record<string, string> = {};
+            let wildcardSegments: string[] = [];
 
-            for (const segment of segments) {
+            // Traverse the trie with proper prioritization
+            for (let i = 0; i < segments.length; i++) {
+                const segment = segments[i];
+
+                // Priority 1: Exact static match (highest priority)
                 if (node.children.has(segment)) {
                     node = node.children.get(segment)!;
-                } else if (node.paramChild) {
+                }
+                // Priority 2: Dynamic parameter match (medium priority)
+                else if (node.paramChild) {
                     node = node.paramChild;
                     params[node.paramName!] = segment;
-                } else {
-                    return { params: {} };
+                }
+                // Priority 3: Collect remaining segments for wildcard (lowest priority)
+                else {
+                    wildcardSegments = segments.slice(i);
+                    break;
                 }
             }
 
-            if (node.route && node.route.handlers[method]) {
+            // Check if we have a route at the current node
+            if (node.route?.handlers[method]) {
                 return { route: node.route, params };
             }
+
+            // If no route found but we have wildcard segments, check for wildcard route
+            if (
+                wildcardSegments.length > 0 &&
+                node.wildcardChild?.route?.handlers[method]
+            ) {
+                // Return wildcard segments so they can be added to req.wildcardParams
+                return {
+                    route: node.wildcardChild.route,
+                    params,
+                    wildcardParams: wildcardSegments,
+                };
+            }
+
             return { params: {} };
         } catch (error) {
             // Log the error for better debugging

--- a/src/core/openapi.ts
+++ b/src/core/openapi.ts
@@ -112,13 +112,27 @@ function buildRequestBody(zodSchema: any): any {
 
 /**
  * Converts a route path from colon-based dynamic segments to OpenAPI's curly brace syntax.
+ * Also handles  wildcard routes.
  *
- * @param routePath The original route path with colon-based dynamic segments (e.g., "/user/:id").
- * @returns The converted route path with curly brace syntax (e.g., "/user/{id}").
+ * @param routePath The original route path with colon-based dynamic segments (e.g., "/user/:id") or wildcards (e.g., "/files/*").
+ * @returns The converted route path with curly brace syntax (e.g., "/user/{id}") or wildcard format (e.g., "/files/*").
  */
 function convertPathForOpenAPI(routePath: string): string {
+    // Fast path: if no special chars, return as-is
+    if (routePath.indexOf(':') === -1 && routePath.indexOf('*') === -1) {
+        return routePath;
+    }
+
     // Replace occurrences of :param with {param}
-    return routePath.replace(/:([a-zA-Z0-9_]+)/g, '{$1}');
+    let converted = routePath.replace(/:([a-zA-Z0-9_]+)/g, '{$1}');
+
+    // Handle wildcard routes
+    // OpenAPI 3.0 doesn't have official wildcard syntax, so we keep /* as-is
+    // This will display in Swagger as /api/files/* which is intuitive and common
+    // Alternative: convert to {path*} format if preferred
+    // converted = converted.replace(/\/\*$/g, '/{path*}');
+
+    return converted;
 }
 
 export function generateOpenAPIDocument(

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,7 +193,95 @@ export class Burger {
             // Create optimized route handler
             if (totalMiddlewareCount === 0) {
                 // Ultra-fast path: no middleware
+                // Pre-compute wildcard segment count for faster extraction
+                const isWildcard = route.isWildcard;
+                // Calculate how many segments come before the wildcard
+                // E.g., "/api/users/:userId/*" has 3 segments before wildcard (api, users, :userId)
+                const baseSegmentCount = isWildcard
+                    ? path.split('/').filter(Boolean).length - 1 // Subtract 1 for the * itself
+                    : 0;
+
                 routes[path] = (request: BurgerRequest) => {
+                    // Extract wildcard params if this is a wildcard route
+                    if (isWildcard) {
+                        // Step 1: Get the pathname from the URL
+                        // Example: "http://localhost:4000/api/users/123/profile?id=1" → "/api/users/123/profile"
+                        const url = request.url;
+
+                        // Find where the path starts (after protocol and domain)
+                        // Example: "http://localhost:4000/api/..." → protocolEnd = 4 (after "http")
+                        const protocolEnd = url.indexOf('://');
+
+                        // Find first "/" after the domain
+                        // Example: "http://localhost:4000/api/..." → pathStart = 21 (the "/" before "api")
+                        const pathStart = url.indexOf('/', protocolEnd + 3);
+
+                        // Find where query parameters start (if any)
+                        // Example: "/api/users/123?id=1" → pathEnd = 15 (at the "?")
+                        const pathEnd = url.indexOf('?', pathStart);
+
+                        // Extract just the pathname without query parameters
+                        // Example: "/api/users/123/profile"
+                        const pathname =
+                            pathEnd === -1
+                                ? url.substring(pathStart) // No query params
+                                : url.substring(pathStart, pathEnd); // Has query params, stop at "?"
+
+                        // Step 2: Extract wildcard segments efficiently
+                        // Example route: "/api/users/:userId/*" has baseSegmentCount = 3
+                        //   - Segment 0: "api"
+                        //   - Segment 1: "users"
+                        //   - Segment 2: ":userId" (or "123" in actual URL)
+                        //   - Segment 3+: wildcard segments we want!
+
+                        if (baseSegmentCount === 0) {
+                            // Fast path: The entire path is wildcard
+                            // Example: "/api/docs/*" where all segments after domain are wildcards
+                            // Just split everything and we're done!
+                            request.wildcardParams = pathname
+                                .split('/')
+                                .filter(Boolean);
+                        } else {
+                            // Optimized path: Skip base segments and only collect wildcard segments
+                            // Example: "/api/users/123/settings/privacy"
+                            //   - We need to skip 3 segments (api, users, 123)
+                            //   - Only collect: ["settings", "privacy"]
+
+                            const wildcardParams: string[] = [];
+                            let segmentCount = 0; // Counts how many segments we've seen
+                            let start = pathname[0] === '/' ? 1 : 0; // Start after leading "/" if present
+
+                            // Loop through each character in the pathname
+                            // When we hit "/" or end of string, we know we found a segment
+                            for (let i = start; i <= pathname.length; i++) {
+                                // Found end of a segment (either "/" or end of string)
+                                if (
+                                    i === pathname.length ||
+                                    pathname[i] === '/'
+                                ) {
+                                    // Make sure it's not an empty segment (from double slashes)
+                                    if (i > start) {
+                                        // Only save segments AFTER we've skipped the base segments
+                                        // Example: If baseSegmentCount=3, save segment 3, 4, 5, etc.
+                                        if (segmentCount >= baseSegmentCount) {
+                                            // Extract this segment from the pathname
+                                            // Example: pathname.substring(5, 13) might give "settings"
+                                            wildcardParams.push(
+                                                pathname.substring(start, i)
+                                            );
+                                        }
+                                        segmentCount++; // Increment count for next segment
+                                    }
+                                    start = i + 1; // Move start position to character after "/"
+                                }
+                            }
+
+                            // Done! wildcardParams now contains only the wildcard segments
+                            // Example: ["settings", "privacy"] instead of ["api", "users", "123", "settings", "privacy"]
+                            request.wildcardParams = wildcardParams;
+                        }
+                    }
+
                     const handler = handlers[request.method];
                     return handler ? handler(request) : this.METHOD_NOT_ALLOWED;
                 };
@@ -227,16 +315,119 @@ export class Burger {
                  * ================================================
                  */
 
+                // Pre-compute wildcard segment count for faster extraction
+                const isWildcard = route.isWildcard;
+                // Calculate how many segments come before the wildcard
+                // E.g., "/api/users/:userId/*" has 3 segments before wildcard (api, users, :userId)
+                const baseSegmentCount = isWildcard
+                    ? path.split('/').filter(Boolean).length - 1 // Subtract 1 for the * itself
+                    : 0;
+
                 // Create handler with middleware
                 routes[path] = (request: BurgerRequest) => {
+                    // Extract wildcard params if this is a wildcard route
+                    if (isWildcard) {
+                        // Step 1: Get the pathname from the URL
+                        // Example: "http://localhost:4000/api/users/123/profile?id=1" → "/api/users/123/profile"
+                        const url = request.url;
+
+                        // Find where the path starts (after protocol and domain)
+                        // Example: "http://localhost:4000/api/..." → protocolEnd = 4 (after "http")
+                        const protocolEnd = url.indexOf('://');
+
+                        // Find first "/" after the domain
+                        // Example: "http://localhost:4000/api/..." → pathStart = 21 (the "/" before "api")
+                        const pathStart = url.indexOf('/', protocolEnd + 3);
+
+                        // Find where query parameters start (if any)
+                        // Example: "/api/users/123?id=1" → pathEnd = 15 (at the "?")
+                        const pathEnd = url.indexOf('?', pathStart);
+
+                        // Extract just the pathname without query parameters
+                        // Example: "/api/users/123/profile"
+                        const pathname =
+                            pathEnd === -1
+                                ? url.substring(pathStart) // No query params
+                                : url.substring(pathStart, pathEnd); // Has query params, stop at "?"
+
+                        // Step 2: Extract wildcard segments efficiently
+                        // Example route: "/api/users/:userId/*" has baseSegmentCount = 3
+                        //   - Segment 0: "api"
+                        //   - Segment 1: "users"
+                        //   - Segment 2: ":userId" (or "123" in actual URL)
+                        //   - Segment 3+: wildcard segments we want!
+
+                        if (baseSegmentCount === 0) {
+                            // Fast path: The entire path is wildcard
+                            // Example: "/api/docs/*" where all segments after domain are wildcards
+                            // Just split everything and we're done!
+                            request.wildcardParams = pathname
+                                .split('/')
+                                .filter(Boolean);
+                        } else {
+                            // Optimized path: Skip base segments and only collect wildcard segments
+                            // Example: "/api/users/123/settings/privacy"
+                            //   - We need to skip 3 segments (api, users, 123)
+                            //   - Only collect: ["settings", "privacy"]
+
+                            const wildcardParams: string[] = [];
+                            let segmentCount = 0; // Counts how many segments we've seen
+                            let start = pathname[0] === '/' ? 1 : 0; // Start after leading "/" if present
+
+                            // Loop through each character in the pathname
+                            // When we hit "/" or end of string, we know we found a segment
+                            for (let i = start; i <= pathname.length; i++) {
+                                // Found end of a segment (either "/" or end of string)
+                                if (
+                                    i === pathname.length ||
+                                    pathname[i] === '/'
+                                ) {
+                                    // Make sure it's not an empty segment (from double slashes)
+                                    if (i > start) {
+                                        // Only save segments AFTER we've skipped the base segments
+                                        // Example: If baseSegmentCount=3, save segment 3, 4, 5, etc.
+                                        if (segmentCount >= baseSegmentCount) {
+                                            // Extract this segment from the pathname
+                                            // Example: pathname.substring(5, 13) might give "settings"
+                                            wildcardParams.push(
+                                                pathname.substring(start, i)
+                                            );
+                                        }
+                                        segmentCount++; // Increment count for next segment
+                                    }
+                                    start = i + 1; // Move start position to character after "/"
+                                }
+                            }
+
+                            // Done! wildcardParams now contains only the wildcard segments
+                            // Example: ["settings", "privacy"] instead of ["api", "users", "123", "settings", "privacy"]
+                            request.wildcardParams = wildcardParams;
+                        }
+                    }
+
                     const handler = handlers[request.method];
                     if (!handler) return this.METHOD_NOT_ALLOWED;
+
                     return this.processMiddleware(
                         request,
                         middlewares,
                         handler
                     );
                 };
+            }
+
+            // For wildcard routes, also register the base path
+            // Bun's /* wildcard may not match the base path itself, so we register both
+            if (route.isWildcard && path.endsWith('/*')) {
+                const basePath = path.slice(0, -2); // Remove "/*" to get base path
+
+                // Only register base path if no static route exists (preserve priority)
+                // Static routes have highest priority: Static > Dynamic > Wildcard
+                if (!routes[basePath]) {
+                    // No static route found, register wildcard for base path
+                    routes[basePath] = routes[path];
+                }
+                // If static route exists, it takes priority (correct behavior)
             }
         }
 
@@ -329,7 +520,7 @@ export class Burger {
             response = await afterStack[i](response);
         }
 
-        // Return the responseF
+        // Return the response
         return response;
     }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -80,15 +80,6 @@ export interface BurgerRequest<
     RequestValidatedProperties extends DefaultRequestProperties = DefaultRequestProperties
 > extends Omit<BunRequest<string>, 'params'> {
     /**
-     * Provides helper to access query parameters as URLSearchParams.
-     * This is a convenience property that allows you to access the query
-     * parameters of the request as a URLSearchParams object, which provides
-     * methods for working with the query parameters like `get(key)`,
-     * `getAll(key)`, `has(key)`, `keys()`, `values()`, `entries()`, and more.
-     */
-    // query: URLSearchParams;
-
-    /**
      * Contains URL parameters extracted from the request path.
      * This property is only present if the request path matches a route
      * with dynamic parameters.
@@ -110,6 +101,15 @@ export interface BurgerRequest<
      * - `body`: Validated request body (if JSON).
      */
     validated: RequestValidatedProperties;
+
+    /**
+     * Contains the wildcard parameters.
+     * This is an optional property that will only be present if
+     * the request path matches a route with a wildcard parameter.
+     * For example, if the route is `/users/[...]`, and the request path is
+     * `/users/123/456`, then the `wildcardParams` property will be `['123', '456']`.
+     */
+    wildcardParams?: string[];
 }
 
 /**
@@ -195,6 +195,13 @@ export interface RouteDefinition {
      * containing the OpenAPI metadata for that method.
      */
     openapi?: openapi;
+
+    /**
+     * Indicates if this route is a wildcard route.
+     * True for routes using the `[...]` syntax.
+     * This property is used internally to identify wildcard routes.
+     */
+    isWildcard?: boolean;
 }
 
 /**
@@ -245,8 +252,10 @@ export interface PageDefinition {
 }
 
 export interface TrieNode {
-    children: Map<string, TrieNode>; // Normal path pieces, like "users"
-    paramChild?: TrieNode; // For dynamic pieces, like ":id"
-    paramName?: string; // Name of the dynamic piece, like "id"
-    route?: RouteDefinition; // The route definition for the node
+    children: Map<string, TrieNode>; // Static path segments, like "users"
+    paramChild?: TrieNode; // Dynamic segments, like ":id"
+    paramName?: string; // Name of dynamic parameter, like "id"
+    wildcardChild?: TrieNode; // Wildcard segments, like "*"
+    isWildcard?: boolean; // True for wildcard routes [...]
+    route?: RouteDefinition; // Route definition at leaf node
 }

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -4,13 +4,21 @@ import type { PageDefinition, RouteDefinition, TrieNode } from '@burgerTypes';
  * Constants for route handling.
  */
 export const ROUTE_CONSTANTS = {
+    // Supported page extensions
     SUPPORTED_PAGE_EXTENSIONS: ['.tsx', '.html'],
+    // Page index files
     PAGE_INDEX_FILES: ['index.tsx', 'index.html'],
+    // Dynamic route constants
     DYNAMIC_SEGMENT_PREFIX: ':',
     DYNAMIC_FOLDER_START: '[',
     DYNAMIC_FOLDER_END: ']',
+    // Grouping folder constants
     GROUPING_FOLDER_START: '(',
     GROUPING_FOLDER_END: ')',
+    // Wildcard route constants
+    WILDCARD_SEGMENT_PREFIX: '*',
+    WILDCARD_SIMPLE: '[...]',
+    WILDCARD_START: '[...',
 };
 
 /**
@@ -29,20 +37,25 @@ export const HTTP_METHODS = [
 /**
  * Calculates the specificity of a route path based on the number of static segments.
  * Static segments increase the score, while dynamic segments (:param) do not.
+ * Wildcard segments (*) have the lowest specificity (highest penalty).
  * @param path The route path to evaluate.
- * @returns The specificity score (higher means more static segments).
+ * @returns The specificity score (higher means more static segments, lower priority for wildcard).
  */
 export const getRouteSpecificity = (path: string): number => {
     const segments = path.split('/').filter(Boolean);
     return segments.reduce((score, segment) => {
+        if (segment.startsWith(ROUTE_CONSTANTS.WILDCARD_SEGMENT_PREFIX)) {
+            return score + 1000; // Wildcard routes get highest penalty (lowest priority)
+        }
         return segment.startsWith(ROUTE_CONSTANTS.DYNAMIC_SEGMENT_PREFIX)
-            ? score
-            : score + 1;
+            ? score + 100 // Dynamic routes get medium penalty
+            : score + 1; // Static routes get minimal penalty
     }, 0);
 };
 
 /**
  * Compares two routes for sorting, prioritizing those with higher specificity (more static segments).
+ * Route prioritization: Static > Dynamic > Wildcard.
  * If specificity is equal, sorts alphabetically by path.
  * @param a The first route to compare.
  * @param b The second route to compare.
@@ -89,6 +102,13 @@ export function collectRoutes(
     if (node.paramChild) {
         const paramPath = `${currentPath}/:${node.paramChild.paramName}`;
         collectRoutes(node.paramChild, paramPath, routes);
+    }
+
+    // Traverse wildcard child if exists (lowest priority)
+    if (node.wildcardChild) {
+        // const wildcardPath = `${currentPath}/${node.wildcardChild.wildcardParamName}`;
+        const wildcardPath = `${currentPath}/${ROUTE_CONSTANTS.WILDCARD_SEGMENT_PREFIX}`;
+        collectRoutes(node.wildcardChild, wildcardPath, routes);
     }
 
     return routes;


### PR DESCRIPTION
Add catch-all routes using [...] folder name to match any path after it. Routes are matched in order: exact paths first, then dynamic routes, then wildcards.

- Add wildcard route handling with [...] folder syntax
- Add wildcardParams to access matched path parts in requests
- Support wildcards inside dynamic routes (/api/users/[userId]/[...])
- Include OpenAPI/Swagger documentation support
- Add examples and update to version 0.4.0