### PR TITLE
feat: auto-add OPTIONS handler for CORS preflight in ApiRouter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 📣 Release Notes
 
-### Version 0.5.0 (October 30, 2025)
+### Version 0.5.0 (November 1, 2025)
 
--   🔧 **Auto-injected OPTIONS handler for CORS preflight:**
+-   🌟 **Feature:** Auto-injected OPTIONS handler for CORS preflight:
 
     -   Automatically injects an OPTIONS handler for CORS preflight when needed
     -   Only injects if the route defines any preflight-triggering methods and
@@ -12,11 +12,23 @@
         DELETE, PATCH)
     -   Does not inject if the route already has an OPTIONS handler
 
--   🔄 **Improved response handling in middleware (after middlewares):**
+-   🌟 **Feature:** Improved response handling in middleware (after
+    middlewares):
+
     -   After middlewares now run even if the current middleware already
         returned a response
     -   After middlewares run in reverse order to make changing the response
         easier and to help with CORS
+
+-   🐛 **Bug Fix:** Fixed TypeScript type resolution for package consumers:
+    -   Users now get full IntelliSense, autocomplete, and type safety out of
+        the box
+    -   Improved build process by removing `tsc-alias` dependency
+    -   Converted `src/types/index.d.ts` to `src/types/index.ts` for proper
+        emission
+    -   Updated all 49 files across `src/` and `examples/` folders
+    -   Build is now faster and more reliable
+    -   Universal compatibility across Bun
 
 ### Version 0.4.0 (October 21, 2025)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Under Development](https://img.shields.io/badge/under%20development-red.svg)](https://github.com/isfhan/burger-api)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Bun](https://img.shields.io/badge/Bun-1.2.20-black?logo=bun)](https://bun.sh)
-[![Version](https://img.shields.io/badge/version-0.4.0-green.svg)](https://github.com/isfhan/burger-api/releases)
+[![Version](https://img.shields.io/badge/version-0.5.0-green.svg)](https://github.com/isfhan/burger-api/releases)
 
 **burger-api** is a modern, open source API framework built on
 [Bun.js](https://bun.sh). It combines the simplicity of file-based routing with
@@ -66,9 +66,9 @@ burger-api is built to offer a robust developer experience through:
 
 ## 📣 Changelog
 
-### Latest Version: 0.5.0 (October 30, 2025)
+### Latest Version: 0.5.0 (November 1, 2025)
 
--   🔧 **Auto-injected OPTIONS handler for CORS preflight:**
+-   🌟 **Feature:** Auto-injected OPTIONS handler for CORS preflight:
 
     -   Automatically injects an OPTIONS handler for CORS preflight when needed
     -   Only injects if the route defines any preflight-triggering methods and
@@ -78,15 +78,21 @@ burger-api is built to offer a robust developer experience through:
         DELETE, PATCH)
     -   Does not inject if the route already has an OPTIONS handler
 
--   🔄 **Improved response handling in middleware (after middlewares):**
+-   🌟 **Feature:** Improved response handling in middleware (after
+    middlewares):
+
     -   After middlewares now run even if the current middleware already
         returned a response
     -   After middlewares run in reverse order to make changing the response
         easier and to help with CORS
 
+-   🐛 **Bug Fix:** Fixed TypeScript type resolution for package consumers:
+    -   Users now get full IntelliSense, autocomplete, and type safety out of
+        the box
+
 ### Previous Version: 0.4.0 (October 21, 2025)
 
--   🎯 **Wildcard Routes:**
+-   🌟 **Feature:** Wildcard Routes:
     -   Added wildcard routes using `[...]` folder name - matches any path after
         it
     -   Create routes that handle multiple path segments automatically
@@ -98,7 +104,7 @@ burger-api is built to offer a robust developer experience through:
 
 ### Previous Version: 0.3.0 (August 15, 2025)
 
--   🔧 **Updated Zod to version 4:**
+-   🌟 **Feature:** Updated Zod to version 4:
     -   Updated Zod version from 3.x to 4.x
     -   Updated built-in request validation middleware to use Zod 4
     -   Updated and better request validation middleware error handling

--- a/examples/error-handling/api/products/[id]/route.ts
+++ b/examples/error-handling/api/products/[id]/route.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Import types
-import type { BurgerRequest, BurgerNext, Middleware } from '@burgerTypes';
+import type { BurgerRequest, BurgerNext, Middleware } from '../../../../../src/index';
 
 // OpenAPI Metadata
 // Developers can provide custom metadata to enrich the docs.

--- a/examples/error-handling/api/products/detail/route.ts
+++ b/examples/error-handling/api/products/detail/route.ts
@@ -1,4 +1,4 @@
-import type { BurgerRequest } from '@src';
+import type { BurgerRequest } from '../../../../../src/index';
 
 export async function GET(req: BurgerRequest) {
     console.log('[GET] Product Detail route invoked');

--- a/examples/error-handling/api/products/route.ts
+++ b/examples/error-handling/api/products/route.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Import types
-import type { BurgerRequest, BurgerNext, Middleware } from '@src';
+import type { BurgerRequest, BurgerNext, Middleware } from '../../../../src/index';
 
 // OpenAPI Metadata
 // Developers can provide custom metadata to enrich the docs.

--- a/examples/error-handling/index.ts
+++ b/examples/error-handling/index.ts
@@ -1,5 +1,5 @@
 // Import stuff from burger-api
-import { Burger, setDir } from '@src';
+import { Burger, setDir } from '../../src/index';
 
 // Import middleware
 import { globalLogger } from './middleware/logger';

--- a/examples/error-handling/middleware/logger.ts
+++ b/examples/error-handling/middleware/logger.ts
@@ -1,4 +1,4 @@
-import type { Middleware, BurgerRequest, BurgerNext } from '@src';
+import type { Middleware, BurgerRequest, BurgerNext } from '../../../src/index';
 
 // Global middleware example: a simple logger.
 export const globalLogger: Middleware = (req: BurgerRequest): BurgerNext => {

--- a/examples/file-base-api-routing/api/(group)/products/route.ts
+++ b/examples/file-base-api-routing/api/(group)/products/route.ts
@@ -1,4 +1,4 @@
-import type { BurgerRequest } from '@src';
+import type { BurgerRequest } from '../../../../../src/index';
 
 export function GET(req: BurgerRequest) {
     const query = new URL(req.url).searchParams;

--- a/examples/file-base-api-routing/api/(group)/profile/[id]/route.ts
+++ b/examples/file-base-api-routing/api/(group)/profile/[id]/route.ts
@@ -1,4 +1,4 @@
-import type { BurgerRequest } from '@src';
+import type { BurgerRequest } from '../../../../../../src/index';
 
 export function GET(req: BurgerRequest) {
     const query = new URL(req.url).searchParams;

--- a/examples/file-base-api-routing/index.ts
+++ b/examples/file-base-api-routing/index.ts
@@ -1,5 +1,5 @@
 // Import burger
-import { Burger, setDir } from '@src';
+import { Burger, setDir } from '../../src/index';
 import { globalMiddleware1 } from './middleware';
 
 // Create a new burger instance

--- a/examples/file-base-api-routing/middleware/index.ts
+++ b/examples/file-base-api-routing/middleware/index.ts
@@ -1,4 +1,4 @@
-import type { Middleware, BurgerNext, BurgerRequest } from '@src';
+import type { Middleware, BurgerNext, BurgerRequest } from '../../../src/index';
 
 export const globalMiddleware1: Middleware = (
     request: BurgerRequest

--- a/examples/file-base-static-page-routing-app/api/products/[id]/route.ts
+++ b/examples/file-base-static-page-routing-app/api/products/[id]/route.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Import types
-import type { BurgerRequest, BurgerNext, Middleware } from '@src';
+import type { BurgerRequest, BurgerNext, Middleware } from '../../../../../src/index';
 
 // OpenAPI Metadata
 // Developers can provide custom metadata to enrich the docs.

--- a/examples/file-base-static-page-routing-app/api/products/detail/route.ts
+++ b/examples/file-base-static-page-routing-app/api/products/detail/route.ts
@@ -1,4 +1,4 @@
-import type { BurgerRequest } from '@src';
+import type { BurgerRequest } from '../../../../../src/index';
 
 export async function GET(req: BurgerRequest) {
     console.log('[GET] Product Detail route invoked');

--- a/examples/file-base-static-page-routing-app/api/products/route.ts
+++ b/examples/file-base-static-page-routing-app/api/products/route.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Import types
-import type { BurgerRequest, BurgerNext, Middleware } from '@src';
+import type { BurgerRequest, BurgerNext, Middleware } from '../../../../src/index';
 
 // OpenAPI Metadata
 // Developers can provide custom metadata to enrich the docs.

--- a/examples/file-base-static-page-routing-app/index.ts
+++ b/examples/file-base-static-page-routing-app/index.ts
@@ -1,5 +1,5 @@
 // Import stuff from burger-api
-import { Burger, setDir } from '@src';
+import { Burger, setDir } from '../../src/index';
 
 // Import middleware
 import { globalLogger } from './middleware/logger';

--- a/examples/file-base-static-page-routing-app/middleware/logger.ts
+++ b/examples/file-base-static-page-routing-app/middleware/logger.ts
@@ -1,4 +1,4 @@
-import type { BurgerRequest, Middleware, BurgerNext } from '@src';
+import type { BurgerRequest, Middleware, BurgerNext } from '../../../src/index';
 
 // Global middleware example: a simple logger.
 export const globalLogger: Middleware = (

--- a/examples/native-server/index.ts
+++ b/examples/native-server/index.ts
@@ -1,5 +1,5 @@
 // Import burger
-import { Burger } from '@src';
+import { Burger } from '../../src/index';
 
 // Create a new burger instance
 const burger = new Burger({

--- a/examples/nested-dynamic-routes/api/users/[userId]/posts/[postId]/route.ts
+++ b/examples/nested-dynamic-routes/api/users/[userId]/posts/[postId]/route.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { BurgerRequest } from '@src';
+import type { BurgerRequest } from '../../../../../../../src/index';
 
 export const schema = {
     get: {

--- a/examples/nested-dynamic-routes/api/users/[userId]/route.ts
+++ b/examples/nested-dynamic-routes/api/users/[userId]/route.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { BurgerRequest } from '@src';
+import type { BurgerRequest } from '../../../../../src/index';
 
 export const schema = {
     get: {

--- a/examples/nested-dynamic-routes/api/users/route.ts
+++ b/examples/nested-dynamic-routes/api/users/route.ts
@@ -1,4 +1,4 @@
-import type { BurgerRequest } from '@src';
+import type { BurgerRequest } from '../../../../src/index';
 
 export async function GET(req: BurgerRequest) {
     return Response.json({

--- a/examples/nested-dynamic-routes/index.ts
+++ b/examples/nested-dynamic-routes/index.ts
@@ -1,4 +1,4 @@
-import { Burger, setDir } from '@src';
+import { Burger, setDir } from '../../src/index';
 
 // Simple test example for nested dynamic routes with Zod validation
 const burger = new Burger({

--- a/examples/openapi-and-swagger-ui/api/products/[id]/route.ts
+++ b/examples/openapi-and-swagger-ui/api/products/[id]/route.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Import types
-import type { BurgerRequest, BurgerNext, Middleware } from '@src';
+import type { BurgerRequest, BurgerNext, Middleware } from '../../../../../src/index';
 
 // OpenAPI Metadata
 // Developers can provide custom metadata to enrich the docs.

--- a/examples/openapi-and-swagger-ui/api/products/route.ts
+++ b/examples/openapi-and-swagger-ui/api/products/route.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Import types
-import type { BurgerRequest, BurgerNext, Middleware } from '@src';
+import type { BurgerRequest, BurgerNext, Middleware } from '../../../../src/index';
 
 // OpenAPI Metadata
 // Developers can provide custom metadata to enrich the docs.

--- a/examples/openapi-and-swagger-ui/index.ts
+++ b/examples/openapi-and-swagger-ui/index.ts
@@ -1,5 +1,5 @@
 // Import stuff from burger-api
-import { Burger, setDir } from '@src';
+import { Burger, setDir } from '../../src/index';
 
 // Import middleware
 import { globalLogger } from './middleware/logger';

--- a/examples/openapi-and-swagger-ui/middleware/logger.ts
+++ b/examples/openapi-and-swagger-ui/middleware/logger.ts
@@ -1,4 +1,4 @@
-import type { Middleware, BurgerRequest, BurgerNext } from '@src';
+import type { Middleware, BurgerRequest, BurgerNext } from '../../../src/index';
 
 // Global middleware example: a simple logger.
 export const globalLogger: Middleware = (req: BurgerRequest): BurgerNext => {

--- a/examples/route-specific-middleware/api/(group)/products/detail/route.ts
+++ b/examples/route-specific-middleware/api/(group)/products/detail/route.ts
@@ -1,4 +1,4 @@
-import type { BurgerNext, BurgerRequest, Middleware } from '@src';
+import type { BurgerNext, BurgerRequest, Middleware } from '../../../../../../src/index';
 
 // Route-specific middleware
 export const middleware: Middleware[] = [

--- a/examples/route-specific-middleware/api/(group)/products/route.ts
+++ b/examples/route-specific-middleware/api/(group)/products/route.ts
@@ -1,4 +1,4 @@
-import type { BurgerNext, BurgerRequest, Middleware } from '@src';
+import type { BurgerNext, BurgerRequest, Middleware } from '../../../../../src/index';
 
 // Route-specific middleware
 export const middleware: Middleware[] = [

--- a/examples/route-specific-middleware/api/(group)/profile/[id]/route.ts
+++ b/examples/route-specific-middleware/api/(group)/profile/[id]/route.ts
@@ -1,4 +1,4 @@
-import type { BurgerNext, BurgerRequest, Middleware } from '@src';
+import type { BurgerNext, BurgerRequest, Middleware } from '../../../../../../src/index';
 
 // Route-specific middleware
 export const middleware: Middleware[] = [

--- a/examples/route-specific-middleware/index.ts
+++ b/examples/route-specific-middleware/index.ts
@@ -1,5 +1,5 @@
 // Import burger
-import { Burger, setDir } from '@src';
+import { Burger, setDir } from '../../src/index';
 import { globalMiddleware1 } from './middleware';
 
 // Create a new burger instance

--- a/examples/route-specific-middleware/middleware/index.ts
+++ b/examples/route-specific-middleware/middleware/index.ts
@@ -1,4 +1,4 @@
-import type { Middleware, BurgerNext, BurgerRequest } from '@src';
+import type { Middleware, BurgerNext, BurgerRequest } from '../../../src/index';
 
 export const globalMiddleware1: Middleware = (
     req: BurgerRequest

--- a/examples/wildcard-routes/api/admin/[...]/route.ts
+++ b/examples/wildcard-routes/api/admin/[...]/route.ts
@@ -1,4 +1,4 @@
-import type { BurgerRequest } from '@src';
+import type { BurgerRequest } from '../../../../../src/index';
 
 /**
  * Admin wildcard route example

--- a/examples/wildcard-routes/api/admin/route.ts
+++ b/examples/wildcard-routes/api/admin/route.ts
@@ -1,4 +1,4 @@
-import type { BurgerRequest } from '@src';
+import type { BurgerRequest } from '../../../../src/index';
 
 /**
  * Static admin route example

--- a/examples/wildcard-routes/api/auth/[...]/route.ts
+++ b/examples/wildcard-routes/api/auth/[...]/route.ts
@@ -1,4 +1,4 @@
-import type { BurgerRequest } from '@src';
+import type { BurgerRequest } from '../../../../../src/index';
 
 /**
  * Documentation wildcard route (no static sibling)

--- a/examples/wildcard-routes/api/users/[userId]/[...]/route.ts
+++ b/examples/wildcard-routes/api/users/[userId]/[...]/route.ts
@@ -1,4 +1,4 @@
-import type { BurgerRequest } from '@src';
+import type { BurgerRequest } from '../../../../../../src/index';
 import { z } from 'zod';
 
 /**

--- a/examples/wildcard-routes/api/users/[userId]/posts/[postId]/route.ts
+++ b/examples/wildcard-routes/api/users/[userId]/posts/[postId]/route.ts
@@ -1,4 +1,4 @@
-import type { BurgerRequest } from '@src';
+import type { BurgerRequest } from '../../../../../../../src/index';
 import { z } from 'zod';
 
 /**

--- a/examples/wildcard-routes/api/users/[userId]/route.ts
+++ b/examples/wildcard-routes/api/users/[userId]/route.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { BurgerRequest } from '@src';
+import type { BurgerRequest } from '../../../../../src/index';
 
 // Dummy users data
 const users = [

--- a/examples/wildcard-routes/api/users/route.ts
+++ b/examples/wildcard-routes/api/users/route.ts
@@ -1,4 +1,4 @@
-import type { BurgerRequest } from '@src';
+import type { BurgerRequest } from '../../../../src/index';
 
 /**
  * Static route example

--- a/examples/wildcard-routes/index.ts
+++ b/examples/wildcard-routes/index.ts
@@ -1,5 +1,5 @@
 // Wildcard Routes Example
-import { Burger, setDir } from '@src';
+import { Burger, setDir } from '../../src/index';
 
 // Create a new burger instance with wildcard routing
 const burger = new Burger({

--- a/examples/zod-based-schema-validation/api/products/[id]/route.ts
+++ b/examples/zod-based-schema-validation/api/products/[id]/route.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Import types
-import type { BurgerNext, BurgerRequest, Middleware } from '@src';
+import type { BurgerNext, BurgerRequest, Middleware } from '../../../../../src/index';
 
 // Export a schema for GET requests.
 export const schema = {

--- a/examples/zod-based-schema-validation/api/products/route.ts
+++ b/examples/zod-based-schema-validation/api/products/route.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Import types
-import type { BurgerNext, BurgerRequest, Middleware } from '@src';
+import type { BurgerNext, BurgerRequest, Middleware } from '../../../../src/index';
 
 // Export a schema for both GET and POST requests.
 // For GET, we validate the query parameters.

--- a/examples/zod-based-schema-validation/index.ts
+++ b/examples/zod-based-schema-validation/index.ts
@@ -1,5 +1,5 @@
 // Import burger
-import { Burger, setDir } from '@src';
+import { Burger, setDir } from '../../src/index';
 import { globalMiddleware1 } from './middleware';
 
 // Create a new burger instance

--- a/examples/zod-based-schema-validation/middleware/index.ts
+++ b/examples/zod-based-schema-validation/middleware/index.ts
@@ -1,4 +1,4 @@
-import type { Middleware, BurgerNext, BurgerRequest } from '@src';
+import type { Middleware, BurgerNext, BurgerRequest } from '../../../src/index';
 
 export const globalMiddleware1: Middleware = (
     req: BurgerRequest

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "build": "tsc --project tsconfig.build.json && tsc-alias -p tsconfig.build.json",
+    "build": "tsc --project tsconfig.build.json",
     "prepare": "bun run build",
     "test": "bun test",
     "dev": "bun run examples/file-base-static-page-routing-app/index.ts"
@@ -81,8 +81,7 @@
     "zod": "^4.0.17"
   },
   "devDependencies": {
-    "@types/bun": "latest",
-    "tsc-alias": "^1.8.16"
+    "@types/bun": "latest"
   },
   "peerDependencies": {
     "typescript": "^5.7.3"

--- a/src/core/api-router.ts
+++ b/src/core/api-router.ts
@@ -8,7 +8,7 @@ import {
     normalizePath,
     ROUTE_CONSTANTS,
     HTTP_METHODS,
-} from '@utils';
+} from '../utils/index';
 
 // Import types
 import type {
@@ -16,7 +16,7 @@ import type {
     RequestHandler,
     RouteDefinition,
     TrieNode,
-} from '@burgerTypes';
+} from '../types/index';
 
 /**
  * ApiRouter class for handling file-based routing.

--- a/src/core/openapi.ts
+++ b/src/core/openapi.ts
@@ -11,7 +11,7 @@ import {
 } from 'zod';
 
 // Import types
-import type { ServerOptions, RouteDefinition } from '@burgerTypes';
+import type { ServerOptions, RouteDefinition } from '../types/index';
 
 /**
  * Maps a Zod type to an OpenAPI schema type.

--- a/src/core/page-router.ts
+++ b/src/core/page-router.ts
@@ -8,10 +8,10 @@ import {
     normalizePath,
     compareRoutes,
     ROUTE_CONSTANTS,
-} from '@utils';
+} from '../utils/index';
 
 // Import types
-import type { PageDefinition } from '@burgerTypes';
+import type { PageDefinition } from '../types/index';
 
 /**
  * PageRouter class for handling file-based page routing.

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -2,9 +2,9 @@
 import { serve } from 'bun';
 
 // Import stuff from utils
-import { errorResponse } from '@utils/error.js';
+import { errorResponse } from '../utils/error';
 
-import type { ServerOptions, FetchHandler } from '@burgerTypes';
+import type { ServerOptions, FetchHandler } from '../types/index';
 
 export class Server {
     private options: ServerOptions;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,16 @@
 // Import stuff  from core
-import { Server } from '@core/server.js';
-import { ApiRouter } from '@core/api-router.js';
-import { PageRouter } from '@core/page-router.js';
-import { generateOpenAPIDocument } from '@core/openapi.js';
-import { swaggerHtml } from '@core/swagger-ui.js';
+import { Server } from './core/server';
+import { ApiRouter } from './core/api-router';
+import { PageRouter } from './core/page-router';
+import { generateOpenAPIDocument } from './core/openapi';
+import { swaggerHtml } from './core/swagger-ui';
 
 // Import utils
-import { collectRoutes } from '@utils';
-import { METHOD_NOT_ALLOWED, NOT_FOUND, OPENAPI_ERROR } from '@utils/response';
+import { collectRoutes } from './utils/index';
+import { METHOD_NOT_ALLOWED, NOT_FOUND, OPENAPI_ERROR } from './utils/response';
 
 // Import middleware
-import { createValidationMiddleware } from '@middleware/validator.js';
+import { createValidationMiddleware } from './middleware/validator';
 
 // Import types
 import type {
@@ -18,7 +18,7 @@ import type {
     Middleware,
     BurgerRequest,
     RequestHandler,
-} from '@burgerTypes';
+} from './types/index';
 import type { HTMLBundle } from 'bun';
 
 export class Burger {
@@ -574,7 +574,7 @@ export class Burger {
 }
 
 // Export utils
-export { setDir } from '@utils';
+export { setDir } from './utils/index';
 
 // Export types
 export type {
@@ -584,4 +584,4 @@ export type {
     BurgerNext,
     Middleware,
     openapi,
-} from '@burgerTypes';
+} from './types/index';

--- a/src/middleware/validator.ts
+++ b/src/middleware/validator.ts
@@ -4,7 +4,7 @@ import type {
     Middleware,
     BurgerRequest,
     BurgerNext,
-} from '@burgerTypes';
+} from '../types/index';
 
 /**
  * createValidationMiddleware:

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -213,9 +213,9 @@ export interface RouteDefinition {
  */
 export type RouteSchema = {
     [method: string]: {
-        params?: z.ZodObject<unknown, unknown>;
-        query?: z.ZodObject<unknown, unknown>;
-        body?: z.ZodObject<unknown, unknown>;
+        params?: z.ZodObject<any, any>;
+        query?: z.ZodObject<any, any>;
+        body?: z.ZodObject<any, any>;
     };
 };
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,4 +1,4 @@
-import { normalizePath } from '@utils';
+import { normalizePath } from './index';
 
 /**
  * Generates an HTTP error response based on the request's "Accept" header.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,7 +7,7 @@ export {
     compareRoutes,
     getRouteSpecificity,
     collectRoutes,
-} from '@utils/routing.js';
+} from './routing';
 
 /**
  * Resolves the given path to the specified directory.

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -1,4 +1,4 @@
-import type { PageDefinition, RouteDefinition, TrieNode } from '@burgerTypes';
+import type { PageDefinition, RouteDefinition, TrieNode } from '../types/index';
 
 /**
  * Constants for route handling.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,19 +27,7 @@
     // Project settings
     "rootDir": ".",
     "outDir": "./dist",
-    "baseUrl": ".",
-    "paths": {
-      "@src/*": ["src/*"],
-      "@core/*": ["src/core/*"],
-      "@utils/*": ["src/utils/*"],  
-      "@middleware/*": ["src/middleware/*"],
-      "@burgerTypes/*": ["src/types/*"],
-      "@src": ["src/index.js"],
-      "@core": ["src/core/index.js"],
-      "@utils": ["src/utils/index.js"],
-      "@middleware": ["src/middleware/index.js"],
-      "@burgerTypes": ["src/types/index.js"],
-    }
+    "baseUrl": "."
   },
   "include": ["src/**/*", "tests/**/*", "examples/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
- Implemented logic to automatically inject an OPTIONS handler for routes that define preflight-triggering methods (POST, PUT, DELETE, PATCH) but lack an OPTIONS handler.
- This enhancement improves CORS support by ensuring proper handling of preflight requests.