### PR TITLE
feat(cli): implement version verification and checksum validation for CLI executables

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -133,6 +133,16 @@ jobs:
               with:
                   path: ./releases
 
+            - name: Get version from tag
+              run: |
+                  if [ "${{ github.event.inputs.version }}" != "" ]; then
+                    VERSION="${{ github.event.inputs.version }}"
+                    VERSION="${VERSION#cli/}"
+                  else
+                    VERSION="${GITHUB_REF#refs/tags/cli/}"
+                  fi
+                  echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
             - name: Generate checksums
               run: |
                   cd releases
@@ -160,18 +170,15 @@ jobs:
                   cp releases/*/* release_assets/
                   cp releases/checksums.txt release_assets/
 
-            - name: Get version from tag
-              id: get_version
+            - name: Verify CLI version in built executable
               run: |
-                  if [ "${{ github.event.inputs.version }}" != "" ]; then
-                    VERSION="${{ github.event.inputs.version }}"
-                    # Strip cli/ prefix if present
-                    VERSION="${VERSION#cli/}"
-                  else
-                    VERSION="${GITHUB_REF#refs/tags/cli/}"
+                  chmod +x release_assets/burger-api-linux
+                  VERSION_OUT=$(./release_assets/burger-api-linux --version 2>&1)
+                  if ! echo "$VERSION_OUT" | grep -qFx "${{ env.VERSION }}"; then
+                    echo "Version mismatch: expected ${{ env.VERSION }}, got: $VERSION_OUT"
+                    exit 1
                   fi
-                  echo "VERSION=${VERSION}" >> $GITHUB_ENV
-              shell: bash
+                  echo "Verified CLI version: $VERSION_OUT"
 
             - name: Create GitHub Release
               uses: softprops/action-gh-release@v1

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burger-api/cli",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Simple command-line tool for Burger API projects",
   "module": "src/index.ts",
   "type": "module",
@@ -20,10 +20,10 @@
     "dev": "bun run src/index.ts",
     "test": "bun test --timeout 30000 ./test",
     "test:build": "bun test test/scanner.test.ts test/virtual-entry.test.ts test/entry-options.test.ts test/build-preserve-options.test.ts",
-    "build:win": "bun build ./src/index.ts --compile --target bun-windows-x64 --outfile dist/burger-api.exe --minify",
-    "build:linux": "bun build ./src/index.ts --compile --target bun-linux-x64 --outfile dist/burger-api-linux --minify",
-    "build:mac": "bun build ./src/index.ts --compile --target bun-darwin-arm64 --outfile dist/burger-api-mac --minify",
-    "build:mac-intel": "bun build ./src/index.ts --compile --target bun-darwin-x64 --outfile dist/burger-api-mac-intel --minify",
+    "build:win": "bun run scripts/build-executable.ts win",
+    "build:linux": "bun run scripts/build-executable.ts linux",
+    "build:mac": "bun run scripts/build-executable.ts mac",
+    "build:mac-intel": "bun run scripts/build-executable.ts mac-intel",
     "build:all": "bun run build:win && bun run build:linux && bun run build:mac && bun run build:mac-intel"
   },
   "dependencies": {

--- a/packages/cli/scripts/build-executable.ts
+++ b/packages/cli/scripts/build-executable.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env bun
+/**
+ * Build CLI executable for a target platform with version injected at compile time.
+ * Usage: bun run scripts/build-executable.ts <win|linux|mac|mac-intel>
+ * Run from packages/cli directory.
+ */
+
+import { readFileSync, mkdirSync } from 'fs';
+import { join, resolve } from 'path';
+
+const PLATFORMS = {
+    win: {
+        target: 'bun-windows-x64',
+        outfile: 'dist/burger-api.exe',
+    },
+    linux: {
+        target: 'bun-linux-x64',
+        outfile: 'dist/burger-api-linux',
+    },
+    mac: {
+        target: 'bun-darwin-arm64',
+        outfile: 'dist/burger-api-mac',
+    },
+    'mac-intel': {
+        target: 'bun-darwin-x64',
+        outfile: 'dist/burger-api-mac-intel',
+    },
+} as const;
+
+type Platform = keyof typeof PLATFORMS;
+
+function main(): void {
+    const platformArg = process.argv[2];
+    if (!platformArg || !(platformArg in PLATFORMS)) {
+        console.error(
+            'Usage: bun run scripts/build-executable.ts <win|linux|mac|mac-intel>'
+        );
+        process.exit(1);
+    }
+    const platform = platformArg as Platform;
+    const { target, outfile } = PLATFORMS[platform];
+
+    const cwd = process.cwd();
+    const pkgPath = join(cwd, 'package.json');
+    let version: string;
+    try {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as {
+            version?: string;
+        };
+        version = pkg.version ?? '0.0.0';
+    } catch {
+        console.error('Could not read version from package.json');
+        process.exit(1);
+    }
+
+    const entryPath = resolve(cwd, 'src/index.ts');
+    const outPath = resolve(cwd, outfile);
+    mkdirSync(resolve(cwd, 'dist'), { recursive: true });
+
+    Bun.build({
+        entrypoints: [entryPath],
+        minify: true,
+        define: {
+            CLI_VERSION: JSON.stringify(version),
+        },
+        compile: {
+            target,
+            outfile: outPath,
+        },
+    })
+        .then((result) => {
+            if (!result.success) {
+                console.error('Build failed');
+                if (result.logs.length) {
+                    for (const log of result.logs) {
+                        console.error(log);
+                    }
+                }
+                process.exit(1);
+            }
+            console.log(`Built ${outfile} (version ${version})`);
+        })
+        .catch((err) => {
+            console.error(err instanceof Error ? err.message : err);
+            process.exit(1);
+        });
+}
+
+main();

--- a/packages/cli/scripts/install/install.ps1
+++ b/packages/cli/scripts/install/install.ps1
@@ -143,7 +143,29 @@ try {
     if (-not (Test-Path $installPath)) {
         throw "Downloaded file not found. Did an antivirus delete it?"
     }
-    
+
+    # Verify checksum when release provides checksums.txt
+    $checksumsUrl = "https://github.com/isfhan/burger-api/releases/download/$latestVersion/checksums.txt"
+    try {
+        $checksumsContent = Invoke-RestMethod -Uri $checksumsUrl -ErrorAction Stop
+        $checksumsText = $checksumsContent | Out-String
+        if ($checksumsText -match "burger-api\.exe.*``([a-fA-F0-9]{64})``") {
+            $expectedHash = $Matches[1].ToLower()
+            $actualHash = (Get-FileHash -Path $installPath -Algorithm SHA256).Hash.ToLower()
+            if ($actualHash -ne $expectedHash) {
+                Remove-Item -Path $installPath -Force -ErrorAction SilentlyContinue
+                throw "Checksum verification failed. The downloaded file may be corrupted or modified."
+            }
+            Print-Info "Checksum verified"
+        }
+    }
+    catch {
+        if ($_.Exception.Message -match "Checksum verification failed") {
+            throw
+        }
+        # checksums.txt missing or unreadable (e.g. older release); skip verification
+    }
+
     Write-Host ""
     Print-Success "Downloaded successfully"
 }

--- a/packages/cli/scripts/install/install.sh
+++ b/packages/cli/scripts/install/install.sh
@@ -122,6 +122,20 @@ echo ""
 
 # Use curl with progress bar for better user experience
 if curl -fL --progress-bar -o "$INSTALL_PATH" "$DOWNLOAD_URL"; then
+    # Verify checksum when release provides checksums.txt
+    CHECKSUMS_URL="https://github.com/isfhan/burger-api/releases/download/$LATEST_VERSION/checksums.txt"
+    if CHECKSUMS=$(curl -sfL "$CHECKSUMS_URL" 2>/dev/null); then
+        EXPECTED_HASH=$(echo "$CHECKSUMS" | grep "$EXECUTABLE_NAME" | grep -oE '`[a-fA-F0-9]{64}`' | tr -d '`' | head -1)
+        if [ -n "$EXPECTED_HASH" ]; then
+            ACTUAL_HASH=$(sha256sum "$INSTALL_PATH" | awk '{print $1}')
+            if [ "$(echo "$ACTUAL_HASH" | tr '[:upper:]' '[:lower:]')" != "$(echo "$EXPECTED_HASH" | tr '[:upper:]' '[:lower:]')" ]; then
+                rm -f "$INSTALL_PATH"
+                print_error "Checksum verification failed. The downloaded file may be corrupted or modified."
+                exit 1
+            fi
+            print_info "Checksum verified"
+        fi
+    fi
     echo ""
     print_success "Downloaded successfully"
 else

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -69,7 +69,7 @@ export const addCommand = new Command('add')
         for (const name of middlewareNames) {
             try {
                 // Check if it exists on GitHub
-                const spin = spinner(`Checking ${name}...`);
+                let spin = spinner(`Checking ${name}...`);
 
                 let exists;
                 try {
@@ -106,6 +106,7 @@ export const addCommand = new Command('add')
                         results.skipped.push(name);
                         continue;
                     }
+                    spin = spinner(`Downloading ${name}...`);
                 }
 
                 // Download the middleware

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -11,6 +11,7 @@
 import { Command } from 'commander';
 import { existsSync } from 'fs';
 import { dirname, resolve } from 'path';
+import type { Spinner } from '../utils/logger';
 import {
     spinner,
     success,
@@ -20,8 +21,50 @@ import {
     formatSize,
     dim,
 } from '../utils/logger';
-import { runVirtualEntryBuild } from '../utils/build/pipeline';
+import {
+    runVirtualEntryBuild,
+    type VirtualBuildResult,
+} from '../utils/build/pipeline';
 import { getProjectName } from '../utils/build/project';
+
+function ensureEntryFileExists(cwd: string, file: string): void {
+    const entryPath = resolve(cwd, file);
+    if (!existsSync(entryPath)) {
+        logError(`Entry file not found: ${file}`);
+        info('Make sure you are in the project directory.');
+        process.exit(1);
+    }
+}
+
+async function runBuildWithSpinner(params: {
+    file: string;
+    cwd: string;
+    spinMessage: string;
+    failMessage: string;
+    buildOptions: Parameters<typeof runVirtualEntryBuild>[0];
+    onBeforeBuild?: (spin: Spinner) => void;
+    onSuccess: (result: VirtualBuildResult, spin: Spinner) => void;
+}): Promise<void> {
+    ensureEntryFileExists(params.cwd, params.file);
+    const spin = spinner(params.spinMessage);
+    try {
+        info('Build-time route discovery enabled.');
+        params.onBeforeBuild?.(spin);
+        const result = await runVirtualEntryBuild(params.buildOptions);
+        if (!result.success) {
+            spin.stop(params.failMessage, true);
+            logError(
+                'Bun.build failed. Check that api/page directories and route files are valid.'
+            );
+            process.exit(1);
+        }
+        params.onSuccess(result, spin);
+    } catch (err) {
+        spin.stop(params.failMessage, true);
+        logError(err instanceof Error ? err.message : 'Unknown error');
+        process.exit(1);
+    }
+}
 
 /**
  * Options for the `build` command.
@@ -73,58 +116,39 @@ export const buildCommand = new Command('build')
     .option('--target <env>', 'Target environment (default: bun)')
     .action(async (file: string, options: BuildCommandOptions) => {
         const cwd = process.cwd();
-        const entryPath = resolve(cwd, file);
-        if (!existsSync(entryPath)) {
-            logError(`Entry file not found: ${file}`);
-            info('Make sure you are in the project directory.');
-            process.exit(1);
-        }
-
-        const spin = spinner('Building project...');
-
-        try {
-            info('Build-time route discovery enabled.');
-
-            const { success: ok, hasPages } = await runVirtualEntryBuild({
+        await runBuildWithSpinner({
+            file,
+            cwd,
+            spinMessage: 'Building project...',
+            failMessage: 'Build failed',
+            buildOptions: {
                 cwd,
                 entryFile: file,
                 outfile: options.outfile,
                 target: options.target || 'bun',
                 minify: options.minify,
                 sourcemap: options.sourcemap,
-            });
-
-            if (!ok) {
-                spin.stop('Build failed', true);
-                logError(
-                    'Bun.build failed. Check that api/page directories and route files are valid.'
-                );
-                process.exit(1);
-            }
-
-            const size = Bun.file(options.outfile).size;
-            const bundleDir = dirname(options.outfile);
-
-            spin.stop('Build completed successfully!');
-            newline();
-            success(`Bundle:  ${options.outfile}  (${formatSize(size)})`);
-            newline();
-            if (hasPages) {
-                info(`Pages and assets are in: ${bundleDir}/`);
-                dim(
-                    'Deploy the entire directory — HTML pages depend on their chunks.'
-                );
-                dim(`Run: bun ${options.outfile}`);
-            } else {
-                info('API-only bundle — self-contained single file.');
-                dim(`Run anywhere: bun ${options.outfile}`);
-            }
-            newline();
-        } catch (err) {
-            spin.stop('Build failed', true);
-            logError(err instanceof Error ? err.message : 'Unknown error');
-            process.exit(1);
-        }
+            },
+            onSuccess: (result, spin) => {
+                const size = Bun.file(options.outfile).size;
+                const bundleDir = dirname(options.outfile);
+                spin.stop('Build completed successfully!');
+                newline();
+                success(`Bundle:  ${options.outfile}  (${formatSize(size)})`);
+                newline();
+                if (result.hasPages) {
+                    info(`Pages and assets are in: ${bundleDir}/`);
+                    dim(
+                        'Deploy the entire directory — HTML pages depend on their chunks.'
+                    );
+                    dim(`Run: bun ${options.outfile}`);
+                } else {
+                    info('API-only bundle — self-contained single file.');
+                    dim(`Run anywhere: bun ${options.outfile}`);
+                }
+                newline();
+            },
+        });
     });
 
 /**
@@ -151,13 +175,6 @@ export const buildExecutableCommand = new Command('build:exec')
     .option('--no-bytecode', 'Disable bytecode compilation')
     .action(async (file: string, options: BuildExecutableOptions) => {
         const cwd = process.cwd();
-        const entryPath = resolve(cwd, file);
-        if (!existsSync(entryPath)) {
-            logError(`Entry file not found: ${file}`);
-            info('Make sure you are in the project directory.');
-            process.exit(1);
-        }
-
         let outfile = options.outfile;
         if (!outfile) {
             const projectName = getProjectName(cwd);
@@ -168,14 +185,14 @@ export const buildExecutableCommand = new Command('build:exec')
                 ? `.build/executable/${projectName}.exe`
                 : `.build/executable/${projectName}`;
         }
+        const outfileFinal = outfile;
 
-        const spin = spinner('Compiling to executable...');
-
-        try {
-            info('Build-time route discovery enabled.');
-            spin.update('Compiling... (this may take a minute)');
-
-            const { success: ok, outputs } = await runVirtualEntryBuild({
+        await runBuildWithSpinner({
+            file,
+            cwd,
+            spinMessage: 'Compiling to executable...',
+            failMessage: 'Compilation failed',
+            buildOptions: {
                 cwd,
                 entryFile: file,
                 outfile,
@@ -183,42 +200,32 @@ export const buildExecutableCommand = new Command('build:exec')
                 minify: options.minify,
                 bytecode: options.bytecode !== false,
                 compile: true,
-            });
-
-            if (!ok) {
-                spin.stop('Compilation failed', true);
-                logError(
-                    'Bun.build failed. Check that api/page directories and route files are valid.'
+            },
+            onBeforeBuild: (spin) =>
+                spin.update('Compiling... (this may take a minute)'),
+            onSuccess: (result, spin) => {
+                const size = existsSync(outfileFinal)
+                    ? Bun.file(outfileFinal).size
+                    : (result.outputs[0]?.size ?? 0);
+                spin.stop('Compilation completed successfully!');
+                newline();
+                success(`Executable: ${outfileFinal}`);
+                if (size > 0) info(`Size: ${formatSize(size)}`);
+                newline();
+                info(
+                    'Standalone binary — copy it anywhere, no Bun required on the target.'
                 );
-                process.exit(1);
-            }
-
-            const size = existsSync(outfile)
-                ? Bun.file(outfile).size
-                : (outputs[0]?.size ?? 0);
-
-            spin.stop('Compilation completed successfully!');
-            newline();
-            success(`Executable: ${outfile}`);
-            if (size > 0) info(`Size: ${formatSize(size)}`);
-            newline();
-            info(
-                'Standalone binary — copy it anywhere, no Bun required on the target.'
-            );
-            dim(
-                'All routes, pages, and assets are embedded inside the binary.'
-            );
-            newline();
-            if (process.platform !== 'win32') {
-                dim(`Make executable: chmod +x ${outfile}`);
-                dim(`Run: ./${outfile}`);
-            } else {
-                dim(`Run: ${outfile}`);
-            }
-            newline();
-        } catch (err) {
-            spin.stop('Compilation failed', true);
-            logError(err instanceof Error ? err.message : 'Unknown error');
-            process.exit(1);
-        }
+                dim(
+                    'All routes, pages, and assets are embedded inside the binary.'
+                );
+                newline();
+                if (process.platform !== 'win32') {
+                    dim(`Make executable: chmod +x ${outfileFinal}`);
+                    dim(`Run: ./${outfileFinal}`);
+                } else {
+                    dim(`Run: ${outfileFinal}`);
+                }
+                newline();
+            },
+        });
     });

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -10,7 +10,7 @@
 import { Command } from 'commander';
 import * as clack from '@clack/prompts';
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { isAbsolute, join, relative, resolve } from 'path';
 import type { CreateOptions } from '../types/index';
 import { createProject, installDependencies } from '../utils/templates';
 import {
@@ -45,6 +45,26 @@ function validateProjectName(name: string): string | undefined {
     return undefined;
 }
 
+/**
+ * Ensure directory name (apiDir/pageDir) resolves under targetDir/src to prevent path traversal.
+ */
+function validateDirUnderSrc(
+    targetDir: string,
+    dirName: string,
+    label: string
+): string | undefined {
+    if (!dirName || dirName.includes('..')) {
+        return `${label} cannot be empty or contain '..'`;
+    }
+    const srcRoot = resolve(targetDir, 'src');
+    const resolved = resolve(targetDir, 'src', dirName);
+    const rel = relative(srcRoot, resolved);
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+        return `${label} must resolve inside the project's src directory`;
+    }
+    return undefined;
+}
+
 export const createCommand = new Command('create')
     .description('Create a new Burger API project')
     .argument('<project-name>', 'Name of your project')
@@ -76,6 +96,32 @@ export const createCommand = new Command('create')
             if (clack.isCancel(options)) {
                 clack.outro('Operation cancelled');
                 process.exit(0);
+            }
+
+            // Validate apiDir/pageDir stay under targetDir/src (prevent path traversal)
+            if (options.useApi) {
+                const apiDirError = validateDirUnderSrc(
+                    targetDir,
+                    options.apiDir || 'api',
+                    'API directory'
+                );
+                if (apiDirError) {
+                    clack.outro('Invalid configuration');
+                    logError(apiDirError);
+                    process.exit(1);
+                }
+            }
+            if (options.usePages) {
+                const pageDirError = validateDirUnderSrc(
+                    targetDir,
+                    options.pageDir || 'pages',
+                    'Page directory'
+                );
+                if (pageDirError) {
+                    clack.outro('Invalid configuration');
+                    logError(pageDirError);
+                    process.exit(1);
+                }
             }
 
             // Show what we're about to create
@@ -154,6 +200,8 @@ async function askQuestions(projectName: string): Promise<CreateOptions> {
                                   return 'Please enter a directory name';
                               if (value.includes(' '))
                                   return 'Directory name cannot contain spaces';
+                              if (value.includes('..'))
+                                  return 'Directory name cannot contain ..';
                           },
                       })
                     : Promise.resolve('api'),
@@ -196,6 +244,8 @@ async function askQuestions(projectName: string): Promise<CreateOptions> {
                                   return 'Please enter a directory name';
                               if (value.includes(' '))
                                   return 'Directory name cannot contain spaces';
+                              if (value.includes('..'))
+                                  return 'Directory name cannot contain ..';
                           },
                       })
                     : Promise.resolve('pages'),

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -11,7 +11,7 @@ import { Command } from 'commander';
 import { getMiddlewareList, getMiddlewareInfo } from '../utils/github';
 import {
     header,
-    spinner,
+    withSpinner,
     error as logError,
     table,
     newline,
@@ -28,54 +28,49 @@ export const listCommand = new Command('list')
     .description('Show available middleware from the ecosystem')
     .alias('ls') // Allow users to type "burger-api ls" too
     .action(async () => {
-        // Show a spinner while fetching from GitHub
-        const spin = spinner('Fetching middleware list from GitHub...');
-
         try {
-            // Get the list of middleware names
-            const middlewareNames = await getMiddlewareList();
+            await withSpinner(
+                'Fetching middleware list from GitHub...',
+                async (spin) => {
+                    const middlewareNames = await getMiddlewareList();
 
-            // Fetch details for each middleware (in parallel for speed!)
-            const middlewareDetails = await Promise.all(
-                middlewareNames.map((name) =>
-                    getMiddlewareInfo(name).catch(() => ({
-                        name,
-                        description: 'No description available',
-                        path: '',
-                        files: [],
-                    }))
-                )
+                    const middlewareDetails = await Promise.all(
+                        middlewareNames.map((name) =>
+                            getMiddlewareInfo(name).catch(() => ({
+                                name,
+                                description: 'No description available',
+                                path: '',
+                                files: [],
+                            }))
+                        )
+                    );
+
+                    spin.stop('Found available middleware!');
+                    newline();
+
+                    header('Available Middleware');
+
+                    const tableData: string[][] = [
+                        ['Name', 'Description'],
+                        ...middlewareDetails.map((m) => [
+                            m.name,
+                            m.description.length > 60
+                                ? m.description.substring(0, 57) + '...'
+                                : m.description,
+                        ]),
+                    ];
+
+                    table(tableData);
+                    newline();
+
+                    info('To add middleware to your project, run:');
+                    command('burger-api add <middleware-name>');
+                    newline();
+                    dim('Example: burger-api add cors logger rate-limiter');
+                    newline();
+                }
             );
-
-            spin.stop('Found available middleware!');
-            newline();
-
-            // Display header
-            header('Available Middleware');
-
-            // Create table data
-            const tableData: string[][] = [
-                ['Name', 'Description'],
-                ...middlewareDetails.map((m) => [
-                    m.name,
-                    m.description.length > 60
-                        ? m.description.substring(0, 57) + '...'
-                        : m.description,
-                ]),
-            ];
-
-            // Show the table
-            table(tableData);
-            newline();
-
-            // Show usage instructions
-            info('To add middleware to your project, run:');
-            command('burger-api add <middleware-name>');
-            newline();
-            dim('Example: burger-api add cors logger rate-limiter');
-            newline();
         } catch (err) {
-            spin.stop('Failed to fetch middleware list', true);
             logError(
                 err instanceof Error
                     ? err.message

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,11 +20,18 @@ import { buildCommand, buildExecutableCommand } from './commands/build';
 import { serveCommand } from './commands/serve';
 import { showBanner } from './utils/logger';
 
+/** Injected at build time when compiling to executable (--define CLI_VERSION). */
+declare const CLI_VERSION: string | undefined;
+
 /**
  * Read CLI version from package.json (single source of truth for publish).
+ * When running as compiled binary, version is injected at build time via CLI_VERSION.
  * @returns The version of the CLI.
  */
 function getVersion(): string {
+    if (typeof CLI_VERSION !== 'undefined') {
+        return CLI_VERSION;
+    }
     try {
         const pkgPath = join(import.meta.dir, '..', 'package.json');
         const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as {
@@ -71,6 +78,26 @@ program.configureOutput({
     writeErr: (str) => {
         process.stderr.write(str);
     },
+});
+
+// Use exit code 2 for usage errors (invalid options/args) per CLI guidelines
+const USAGE_ERROR_CODES = [
+    'commander.unknownOption',
+    'commander.unknownArgument',
+    'commander.missingMandatoryOptionValue',
+    'commander.invalidOptionArgument',
+    'commander.invalidArgument',
+];
+program.exitOverride((err) => {
+    const errorCode = (err as { code?: string }).code;
+    const code =
+        err.exitCode === 0
+            ? 0
+            : typeof errorCode === 'string' &&
+                USAGE_ERROR_CODES.includes(errorCode)
+              ? 2
+              : 1;
+    process.exit(code);
 });
 
 // Run the CLI - this parses the arguments the user typed

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -7,7 +7,9 @@
 
 import { existsSync } from 'fs';
 import { join } from 'path';
+import { pathToFileURL } from 'url';
 import type { BuildConfig } from '../types/index';
+import { warning } from './logger';
 
 const CONVENTION_DEFAULTS: BuildConfig = {
     apiDir: './src/api',
@@ -41,15 +43,16 @@ export async function resolveBuildConfig(cwd: string): Promise<BuildConfig> {
     }
 
     try {
-        const mod = await import(configPath);
+        const configUrl = pathToFileURL(configPath).href;
+        const mod = await import(configUrl);
         const user = mod.default ?? mod;
         if (!user || typeof user !== 'object') {
             return { ...CONVENTION_DEFAULTS };
         }
         return mergeBuildConfig(CONVENTION_DEFAULTS, user);
     } catch (err) {
-        console.warn(
-            `[burger-api] Could not load ${configPath}: ${err instanceof Error ? err.message : String(err)}. Using convention defaults.`
+        warning(
+            `Could not load ${configPath}: ${err instanceof Error ? err.message : String(err)}. Using convention defaults.`
         );
         return { ...CONVENTION_DEFAULTS };
     }
@@ -60,8 +63,7 @@ function mergeBuildConfig(
     user: Record<string, unknown>
 ): BuildConfig {
     return {
-        apiDir:
-            typeof user.apiDir === 'string' ? user.apiDir : defaults.apiDir,
+        apiDir: typeof user.apiDir === 'string' ? user.apiDir : defaults.apiDir,
         pageDir:
             typeof user.pageDir === 'string' ? user.pageDir : defaults.pageDir,
         apiPrefix:
@@ -72,7 +74,6 @@ function mergeBuildConfig(
             typeof user.pagePrefix === 'string'
                 ? user.pagePrefix
                 : defaults.pagePrefix,
-        debug:
-            typeof user.debug === 'boolean' ? user.debug : defaults.debug,
+        debug: typeof user.debug === 'boolean' ? user.debug : defaults.debug,
     };
 }

--- a/packages/cli/src/utils/github.ts
+++ b/packages/cli/src/utils/github.ts
@@ -14,16 +14,36 @@ import type { GitHubFile, MiddlewareInfo } from '../types/index';
 import { unlinkSync } from 'fs';
 
 /**
- * Configuration for GitHub repository
- * Change these if you fork the project or want to test with a different repo
+ * Configuration for GitHub repository.
+ * Override via env: BURGER_API_REPO_OWNER, BURGER_API_REPO_NAME, BURGER_API_BRANCH.
  */
-const REPO_OWNER = 'isfhan';
-const REPO_NAME = 'burger-api';
-const BRANCH = 'main';
+const REPO_OWNER = process.env.BURGER_API_REPO_OWNER ?? 'isfhan';
+const REPO_NAME = process.env.BURGER_API_REPO_NAME ?? 'burger-api';
+const BRANCH = process.env.BURGER_API_BRANCH ?? 'main';
 
 // Build the URLs we'll use to access GitHub
 const RAW_URL = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${BRANCH}`;
 const API_URL = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}`;
+
+const FETCH_TIMEOUT_MS = 20_000;
+
+function createFetchSignal(): AbortSignal {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    controller.signal.addEventListener('abort', () => clearTimeout(timer), {
+        once: true,
+    });
+    return controller.signal;
+}
+
+function wrapFetchError(err: unknown, fallbackMessage: string): Error {
+    if (err instanceof Error && err.name === 'AbortError') {
+        return new Error(
+            'Request timed out. Please check your internet connection.'
+        );
+    }
+    return new Error(err instanceof Error ? err.message : fallbackMessage);
+}
 
 /**
  * Get list of available middleware from GitHub
@@ -41,9 +61,9 @@ export async function getMiddlewareList(): Promise<string[]> {
         const response = await fetch(
             `${API_URL}/contents/ecosystem/middlewares`,
             {
+                signal: createFetchSignal(),
                 headers: {
                     Accept: 'application/vnd.github.v3+json',
-                    // Add User-Agent to be nice to GitHub
                     'User-Agent': 'burger-api-cli',
                 },
             }
@@ -64,8 +84,8 @@ export async function getMiddlewareList(): Promise<string[]> {
             .map((f) => f.name)
             .sort();
     } catch (err) {
-        // Provide helpful error message
-        throw new Error(
+        throw wrapFetchError(
+            err,
             'Could not get middleware list from GitHub. Please check your internet connection.'
         );
     }
@@ -87,6 +107,7 @@ export async function getMiddlewareInfo(name: string): Promise<MiddlewareInfo> {
         const response = await fetch(
             `${API_URL}/contents/ecosystem/middlewares/${name}`,
             {
+                signal: createFetchSignal(),
                 headers: {
                     Accept: 'application/vnd.github.v3+json',
                     'User-Agent': 'burger-api-cli',
@@ -108,7 +129,9 @@ export async function getMiddlewareInfo(name: string): Promise<MiddlewareInfo> {
 
         if (readmeFile && readmeFile.download_url) {
             try {
-                const readmeResponse = await fetch(readmeFile.download_url);
+                const readmeResponse = await fetch(readmeFile.download_url, {
+                    signal: createFetchSignal(),
+                });
                 const readmeContent = await readmeResponse.text();
 
                 // Extract first non-empty line after the title as description
@@ -132,7 +155,10 @@ export async function getMiddlewareInfo(name: string): Promise<MiddlewareInfo> {
             files: files.map((f) => f.name),
         };
     } catch (err) {
-        throw new Error(`Could not get info for middleware "${name}"`);
+        throw wrapFetchError(
+            err,
+            `Could not get info for middleware "${name}"`
+        );
     }
 }
 
@@ -154,8 +180,9 @@ export async function downloadFile(
         // Build the URL to the raw file content
         const url = `${RAW_URL}/${path}`;
 
-        // Download using Bun's native fetch
-        const response = await fetch(url);
+        const response = await fetch(url, {
+            signal: createFetchSignal(),
+        });
 
         if (!response.ok) {
             throw new Error(`Could not download ${path}`);
@@ -168,7 +195,8 @@ export async function downloadFile(
         // Bun.write is much faster than Node's fs.writeFile!
         await Bun.write(destination, content);
     } catch (err) {
-        throw new Error(
+        throw wrapFetchError(
+            err,
             `Failed to download ${path}: ${
                 err instanceof Error ? err.message : 'Unknown error'
             }`
@@ -246,6 +274,7 @@ export async function middlewareExists(name: string): Promise<boolean> {
         const response = await fetch(
             `${API_URL}/contents/ecosystem/middlewares/${name}`,
             {
+                signal: createFetchSignal(),
                 headers: {
                     Accept: 'application/vnd.github.v3+json',
                     'User-Agent': 'burger-api-cli',

--- a/packages/cli/src/utils/logger.ts
+++ b/packages/cli/src/utils/logger.ts
@@ -380,6 +380,27 @@ export function spinner(message: string): Spinner {
 }
 
 /**
+ * Run an async command with a spinner. On throw, stops the spinner with error state and rethrows.
+ * Use so catch blocks do not need to remember to stop the spinner.
+ *
+ * @param message - Spinner message
+ * @param fn - Async callback receiving the spinner
+ * @returns Result of fn
+ */
+export async function withSpinner<T>(
+    message: string,
+    fn: (spin: Spinner) => Promise<T>
+): Promise<T> {
+    const spin = new Spinner(message);
+    try {
+        return await fn(spin);
+    } catch (err) {
+        spin.stop(message.replace(/\s*\.\.\.\s*$/, '') + ' failed', true);
+        throw err;
+    }
+}
+
+/**
  * Format a file size in a human-readable way
  * Converts bytes to KB, MB, etc.
  *

--- a/packages/cli/src/utils/templates.ts
+++ b/packages/cli/src/utils/templates.ts
@@ -1142,7 +1142,12 @@ export async function installDependencies(projectDir: string): Promise<void> {
         const exitCode = await proc.exited;
 
         if (exitCode !== 0) {
-            throw new Error('bun install failed');
+            const stderrText = await new Response(proc.stderr).text();
+            const message =
+                stderrText.trim().length > 0
+                    ? `bun install failed:\n${stderrText.trim()}`
+                    : 'bun install failed';
+            throw new Error(message);
         }
 
         spin.stop('Dependencies installed!');


### PR DESCRIPTION
- Added a new script to build CLI executables with version injected at compile time.
- Updated the release workflow to retrieve the version from tags or inputs.
- Enhanced installation scripts to verify checksums for downloaded files.
- Bumped CLI version to 0.9.4 in package.json.
- Refactored build commands to improve error handling and user feedback.